### PR TITLE
DOC: Use valid Git branch name in instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Requirements:
 
 3. Create a new branch for your new theme::
 
-    $ git checkout -b "Add <pypi-pkg-name-of-theme>"
+    $ git checkout -b <pypi-pkg-name-of-theme>
 
 4. Build the docker container (this may take a long time)::
 


### PR DESCRIPTION
When I use the command as suggested:

    git checkout -b "Add sphinx-whatever-theme"

... I get the error:

    fatal: 'Add sphinx-whatever-theme' is not a valid branch name.

... which is not surprising, because the branch name contains a space.