### PR TITLE
Add Documatt Theme

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -98,6 +98,11 @@
       "pypi": "sphinx-typo3-theme"
     },
     {
+      "config": "sphinx_documatt_theme",
+      "display": "Documatt Theme",
+      "pypi": "sphinx_documatt_theme"
+    },
+    {
       "config": "press",
       "display": "press",
       "pypi": "sphinx_press_theme"


### PR DESCRIPTION
Second attempt :-)

Hello, is it possible to add my "Documatt Theme"? It was originally for just my blog, but I open-sourced it recently.

* package name is `sphinx-documatt-theme`
* `html_theme` is `sphinx_documatt_theme`
* PyPI: https://pypi.org/project/sphinx-documatt-theme/
* real demo: https://blog.documatt.com/

All added to themes.json.