### PR TITLE
insipid theme: add options for Github icon and source links

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -81,7 +81,9 @@
     {
       "config": {
         "html_theme": "insipid",
-        "html_add_permalinks": "'\\N{SECTION SIGN}'"
+        "html_add_permalinks": "'\\N{SECTION SIGN}'",
+        "html_copy_source": "False",
+        "html_context": "{'display_github': True, 'github_user': 'sphinx-themes', 'github_repo': 'sphinx-themes.org', 'conf_py_path': '/sample-docs/', 'commit': 'master'}"
       },
       "display": "An Insipid Sphinx Theme (with initially hidden sidebar)",
       "pypi": "insipid-sphinx-theme"

--- a/themes.json
+++ b/themes.json
@@ -80,10 +80,10 @@
     },
     {
       "config": {
-        "html_theme": "insipid",
         "html_add_permalinks": "'\\N{SECTION SIGN}'",
+        "html_context": "{'display_github': True, 'github_user': 'sphinx-themes', 'github_repo': 'sphinx-themes.org', 'conf_py_path': '/sample-docs/', 'commit': 'master'}",
         "html_copy_source": "False",
-        "html_context": "{'display_github': True, 'github_user': 'sphinx-themes', 'github_repo': 'sphinx-themes.org', 'conf_py_path': '/sample-docs/', 'commit': 'master'}"
+        "html_theme": "insipid"
       },
       "display": "An Insipid Sphinx Theme (with initially hidden sidebar)",
       "pypi": "insipid-sphinx-theme"


### PR DESCRIPTION
When everything goes well, this should add a Github icon with a link to this repo.

And it should add source links to the footer with links to the source files here on Github (on the `master` branch).