### PR TITLE
Port hbp-sphinx-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -74,6 +74,17 @@
       "pypi": "guzzle-sphinx-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "hbp_sphinx_theme"
+        ],
+        "html_theme": "hbp_sphinx_theme",
+        "html_theme_path": "[hbp_sphinx_theme.get_html_theme_path()]",
+      },
+      "display": "hbp-sphinx-theme",
+      "pypi": "hbp-sphinx-theme"
+    },
+    {
       "config": "insegel",
       "display": "insegel",
       "pypi": "insegel"

--- a/themes.json
+++ b/themes.json
@@ -79,7 +79,7 @@
           "hbp_sphinx_theme"
         ],
         "html_theme": "hbp_sphinx_theme",
-        "html_theme_path": "[hbp_sphinx_theme.get_html_theme_path()]",
+        "html_theme_path": "[hbp_sphinx_theme.get_html_theme_path()]"
       },
       "display": "hbp-sphinx-theme",
       "pypi": "hbp-sphinx-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'hbp_sphinx_theme'
import hbp_sphinx_theme
html_theme_path = [hbp_sphinx_theme.get_html_theme_path()]
```