### PR TITLE
Port jupyter-sphinx-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -95,7 +95,7 @@
         ],
         "html_sidebars": "{'**': ['sidebartoc.html']}",
         "html_theme": "jupyter",
-        "html_theme_path": "jupyter_sphinx_theme.get_html_theme_path()",
+        "html_theme_path": "jupyter_sphinx_theme.get_html_theme_path()"
       },
       "display": "jupyter-sphinx-theme",
       "pypi": "jupyter-sphinx-theme"

--- a/themes.json
+++ b/themes.json
@@ -89,6 +89,18 @@
       "pypi": "insipid-sphinx-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "jupyter_sphinx_theme"
+        ],
+        "html_sidebars": "{'**': ['sidebartoc.html']}",
+        "html_theme": "jupyter",
+        "html_theme_path": "jupyter_sphinx_theme.get_html_theme_path()",
+      },
+      "display": "jupyter-sphinx-theme",
+      "pypi": "jupyter-sphinx-theme"
+    },
+    {
       "config": "logilab",
       "display": "Logilab",
       "pypi": "logilab-sphinx-themes"


### PR DESCRIPTION
To advance #25.

The previous `conf.py` was:

```
from jupyter_sphinx_theme import *
init_theme()
```

Since `from xyz import *` doesn't seem to be supported, I've extracted the relevant parts manually.

The `import` would do more things, but I think most of them are unnecessary.
See also https://github.com/jupyter/jupyter-sphinx-theme/blob/6d954c051f89eb74dc43b82b2231ac544845fb48/jupyter_sphinx_theme/__init__.py.