### PR TITLE
Port kotti_docs_theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -89,6 +89,17 @@
       "pypi": "insipid-sphinx-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "kotti_docs_theme"
+        ],
+        "html_theme": "kotti_docs_theme",
+        "html_theme_path": "[kotti_docs_theme.get_theme_dir()]"
+      },
+      "display": "kotti_docs_theme",
+      "pypi": "kotti_docs_theme"
+    },
+    {
       "config": "logilab",
       "display": "Logilab",
       "pypi": "logilab-sphinx-themes"

--- a/themes.json
+++ b/themes.json
@@ -97,7 +97,7 @@
         "html_theme_path": "[kotti_docs_theme.get_theme_dir()]"
       },
       "display": "kotti_docs_theme",
-      "pypi": "kotti_docs_theme"
+      "pypi": "kotti-docs-theme"
     },
     {
       "config": "logilab",


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'kotti_docs_theme'
import kotti_docs_theme
html_theme_path = [kotti_docs_theme.get_theme_dir()]
```