### PR TITLE
Port msmb_theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -117,6 +117,17 @@
       "pypi": "mozilla-sphinx-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "msmb_theme"
+        ],
+        "html_theme": "msmb_theme",
+        "html_theme_path": "[msmb_theme.get_html_theme_path()]"
+      },
+      "display": "msmb_theme",
+      "pypi": "msmb-theme"
+    },
+    {
       "config": "python_docs_theme",
       "display": "Python Documentation Theme",
       "pypi": "python-docs-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'msmb_theme'
import msmb_theme
html_theme_path = [msmb_theme.get_html_theme_path()]
```