### PR TITLE
Port murray to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -117,6 +117,17 @@
       "pypi": "mozilla-sphinx-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "murray"
+        ],
+        "html_theme": "murray",
+        "html_theme_path": "[murray.get_html_theme_path()]"
+      },
+      "display": "murray",
+      "pypi": "murray"
+    },
+    {
       "config": "python_docs_theme",
       "display": "Python Documentation Theme",
       "pypi": "python-docs-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'murray'
import murray
html_theme_path = [murray.get_html_theme_path()]
```