### PR TITLE
Port oe-sphinx-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -117,6 +117,17 @@
       "pypi": "mozilla-sphinx-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "oe_sphinx_theme"
+        ],
+        "html_theme": "oe_sphinx",
+        "html_theme_path": "[oe_sphinx_theme.get_theme_dir()]"
+      },
+      "display": "oe-sphinx-theme",
+      "pypi": "oe-sphinx-theme"
+    },
+    {
       "config": "python_docs_theme",
       "display": "Python Documentation Theme",
       "pypi": "python-docs-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'oe_sphinx'
import oe_sphinx_theme
html_theme_path = [oe_sphinx_theme.get_theme_dir()]
```