### PR TITLE
Port ovs-sphinx-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -162,6 +162,17 @@
       "pypi": "murray"
     },
     {
+      "config": {
+        "_imports": [
+          "ovs_sphinx_theme"
+        ],
+        "html_theme": "ovs",
+        "html_theme_path": "[ovs_sphinx_theme.get_theme_dir()]"
+      },
+      "display": "ovs-sphinx-theme",
+      "pypi": "ovs-sphinx-theme"
+    },
+    {
       "config": "python_docs_theme",
       "display": "Python Documentation Theme",
       "pypi": "python-docs-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'ovs'
import ovs_sphinx_theme
html_theme_path = [ovs_sphinx_theme.get_theme_dir()]
```