### PR TITLE
Port pietroalbini-sphinx-themes to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -117,6 +117,17 @@
       "pypi": "mozilla-sphinx-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "pietroalbini_sphinx_themes"
+        ],
+        "html_theme": "pietroalbini",
+        "html_theme_path": "[pietroalbini_sphinx_themes.themes_path()]"
+      },
+      "display": "pietroalbini-sphinx-themes",
+      "pypi": "pietroalbini-sphinx-themes"
+    },
+    {
       "config": "python_docs_theme",
       "display": "Python Documentation Theme",
       "pypi": "python-docs-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'pietroalbini'
import pietroalbini_sphinx_themes
html_theme_path = [pietroalbini_sphinx_themes.themes_path()]
```