### PR TITLE
Port quark-sphinx-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -123,6 +123,17 @@
     },
     {
       "config": {
+        "_imports": [
+          "quark_sphinx_theme"
+        ],
+        "html_theme": "quark",
+        "html_theme_path": "[quark_sphinx_theme.get_path()]"
+      },
+      "display": "quark-sphinx-theme",
+      "pypi": "quark-sphinx-theme"
+    },
+    {
+      "config": {
         "_extensions": [
           "sphinx_ansible_theme.ext.pygments_lexer"
         ],


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'quark'
import quark_sphinx_theme
html_theme_path = [quark_sphinx_theme.get_path()]
```