### PR TITLE
Port renga-sphinx-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -123,6 +123,17 @@
     },
     {
       "config": {
+        "_imports": [
+          "renga_sphinx_theme"
+        ],
+        "html_theme": "renga",
+        "html_theme_path": "[renga_sphinx_theme.get_path()]"
+      },
+      "display": "renga-sphinx-theme",
+      "pypi": "renga-sphinx-theme"
+    },
+    {
+      "config": {
         "_extensions": [
           "sphinx_ansible_theme.ext.pygments_lexer"
         ],


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'renga'
import renga_sphinx_theme
html_theme_path = [renga_sphinx_theme.get_path()]
```