### PR TITLE
Port renku-sphinx-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -122,6 +122,11 @@
       "pypi": "python-docs-theme"
     },
     {
+      "config": "renku",
+      "display": "renku-sphinx-theme",
+      "pypi": "renku-sphinx-theme"
+    },
+    {
       "config": {
         "_extensions": [
           "sphinx_ansible_theme.ext.pygments_lexer"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'renku'
```