### PR TITLE
Port solar-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -123,6 +123,17 @@
     },
     {
       "config": {
+        "_imports": [
+          "solar_theme"
+        ],
+        "html_theme": "solar_theme",
+        "html_theme_path": "[solar_theme.theme_path]"
+      },
+      "display": "solar-theme",
+      "pypi": "solar-theme"
+    },
+    {
+      "config": {
         "_extensions": [
           "sphinx_ansible_theme.ext.pygments_lexer"
         ],


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'solar_theme'
import solar_theme
html_theme_path = [solar_theme.theme_path]
```