### PR TITLE
Port sphinx_sizzle_theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -283,6 +283,11 @@
       "pypi": "sphinx-press-theme"
     },
     {
+      "config": "sizzle",
+      "display": "sphinx_sizzle_theme",
+      "pypi": "sphinx-sizzle-theme"
+    },
+    {
       "config": "sphinx_typo3_theme",
       "display": "TYPO3 theme for docs.typo3.org",
       "pypi": "sphinx-typo3-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'sizzle'
```