### PR TITLE
Port sphinx-ustack-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -288,6 +288,11 @@
       "pypi": "sphinx-typo3-theme"
     },
     {
+      "config": "sphinx_ustack_theme",
+      "display": "sphinx-ustack-theme",
+      "pypi": "sphinx-ustack-theme"
+    },
+    {
       "config": "agogo",
       "display": "agogo",
       "pypi": "sphinx"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'sphinx_ustack_theme'
```