### PR TITLE
Port cloud_sptheme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -38,6 +38,11 @@
       "pypi": "caktus-sphinx-theme"
     },
     {
+      "config": "cloud",
+      "display": "cloud_sptheme",
+      "pypi": "cloud-sptheme"
+    },
+    {
       "config": {
         "_extensions": [
           "edx_theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'cloud'
```