### PR TITLE
Port sphinx_materialdesign_theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -300,6 +300,11 @@
       "pypi": "sphinx-drove-theme"
     },
     {
+      "config": "sphinx_materialdesign_theme",
+      "display": "sphinx_materialdesign_theme",
+      "pypi": "sphinx-materialdesign-theme"
+    },
+    {
       "config": "press",
       "display": "press",
       "pypi": "sphinx-press-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'sphinx_materialdesign_theme'
```