### PR TITLE
Port sphinx_theme_pd to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -310,6 +310,17 @@
       "pypi": "sphinx-sizzle-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "sphinx_theme_pd"
+        ],
+        "html_theme": "sphinx_theme_pd",
+        "html_theme_path": "[sphinx_theme_pd.get_html_theme_path()]"
+      },
+      "display": "sphinx_theme_pd",
+      "pypi": "sphinx-theme-pd"
+    },
+    {
       "config": "sphinx_typo3_theme",
       "display": "TYPO3 theme for docs.typo3.org",
       "pypi": "sphinx-typo3-theme"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'sphinx_theme_pd'
import sphinx_theme_pd
html_theme_path = [sphinx_theme_pd.get_html_theme_path()]
```