### PR TITLE
Port sphinx-better-theme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -279,6 +279,17 @@
       "pypi": "sphinx-bernard-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "better"
+        ],
+        "html_theme": "better",
+        "html_theme_path": "[better.better_theme_path]"
+      },
+      "display": "sphinx-better-theme",
+      "pypi": "sphinx-better-theme"
+    },
+    {
       "config": "sphinx_celery",
       "display": "Celery Theme",
       "pypi": "sphinx-celery"


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'better'
from better import better_theme_path
html_theme_path = [better_theme_path]
```