### PR TITLE
Port sphinxcontrib-rextheme to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -320,6 +320,11 @@
       "pypi": "sphinx-ustack-theme"
     },
     {
+      "config": "rex",
+      "display": "sphinxcontrib-rextheme",
+      "pypi": "sphinxcontrib-rextheme"
+    },
+    {
       "config": "agogo",
       "display": "agogo",
       "pypi": "sphinx"

--- a/themes.json
+++ b/themes.json
@@ -320,7 +320,7 @@
       "pypi": "sphinx-ustack-theme"
     },
     {
-      "config": "rex",
+      "config": "rextheme",
       "display": "sphinxcontrib-rextheme",
       "pypi": "sphinxcontrib-rextheme"
     },


### PR DESCRIPTION
To advance #25.

Previous `conf.py`:

```
html_theme = 'rex'
```