### PR TITLE
Port multiple themes to v2

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -383,19 +383,9 @@
       "pypi": "sphinxjp-themes-basicstrap"
     },
     {
-      "config": "s6",
-      "display": "sphinxjp.themes.s6",
-      "pypi": "sphinxjp-themes-s6"
-    },
-    {
       "config": "sphinxjp",
       "display": "sphinxjp.themes.sphinxjp",
       "pypi": "sphinxjp-themes-sphinxjp"
-    },
-    {
-      "config": "trstyle",
-      "display": "sphinxjp.themes.trstyle",
-      "pypi": "sphinxjp-themes-trstyle"
     },
     {
       "config": {

--- a/themes.json
+++ b/themes.json
@@ -383,21 +383,6 @@
       "pypi": "sphinxjp-themes-basicstrap"
     },
     {
-      "config": "dotted",
-      "display": "sphinxjp.themes.dotted",
-      "pypi": "sphinxjp-themes-dotted"
-    },
-    {
-      "config": "htmlslide",
-      "display": "sphinxjp.themes.htmlslide",
-      "pypi": "sphinxjp-themes-htmlslide"
-    },
-    {
-      "config": "revealjs",
-      "display": "sphinxjp.themes.revealjs",
-      "pypi": "sphinxjp-themes-revealjs"
-    },
-    {
       "config": "s6",
       "display": "sphinxjp.themes.s6",
       "pypi": "sphinxjp-themes-s6"

--- a/themes.json
+++ b/themes.json
@@ -388,11 +388,6 @@
       "pypi": "sphinxjp-themes-dotted"
     },
     {
-      "config": "gopher",
-      "display": "sphinxjp.themes.gopher",
-      "pypi": "sphinxjp-themes-gopher"
-    },
-    {
       "config": "htmlslide",
       "display": "sphinxjp.themes.htmlslide",
       "pypi": "sphinxjp-themes-htmlslide"

--- a/themes.json
+++ b/themes.json
@@ -362,6 +362,11 @@
       "pypi": "sphinx-uedoc-theme"
     },
     {
+      "config": "sphinx_ustack_theme",
+      "display": "sphinx-ustack-theme",
+      "pypi": "sphinx-ustack-theme"
+    },
+    {
       "config": {
         "_imports": [
           "sphinxbootstrap4theme"
@@ -375,42 +380,42 @@
     {
       "config": "basicstrap",
       "display": "sphinxjp.themes.basicstrap",
-      "pypi": "sphinxjp.themes.basicstrap"
+      "pypi": "sphinxjp-themes-basicstrap"
     },
     {
       "config": "dotted",
       "display": "sphinxjp.themes.dotted",
-      "pypi": "sphinxjp.themes.dotted"
+      "pypi": "sphinxjp-themes-dotted"
     },
     {
       "config": "gopher",
       "display": "sphinxjp.themes.gopher",
-      "pypi": "sphinxjp.themes.gopher"
+      "pypi": "sphinxjp-themes-gopher"
     },
     {
       "config": "htmlslide",
       "display": "sphinxjp.themes.htmlslide",
-      "pypi": "sphinxjp.themes.htmlslide"
+      "pypi": "sphinxjp-themes-htmlslide"
     },
     {
       "config": "revealjs",
       "display": "sphinxjp.themes.revealjs",
-      "pypi": "sphinxjp.themes.revealjs"
+      "pypi": "sphinxjp-themes-revealjs"
     },
     {
       "config": "s6",
       "display": "sphinxjp.themes.s6",
-      "pypi": "sphinxjp.themes.s6"
+      "pypi": "sphinxjp-themes-s6"
     },
     {
       "config": "sphinxjp",
       "display": "sphinxjp.themes.sphinxjp",
-      "pypi": "sphinxjp.themes.sphinxjp"
+      "pypi": "sphinxjp-themes-sphinxjp"
     },
     {
       "config": "trstyle",
       "display": "sphinxjp.themes.trstyle",
-      "pypi": "sphinxjp.themes.trstyle"
+      "pypi": "sphinxjp-themes-trstyle"
     },
     {
       "config": {
@@ -433,7 +438,7 @@
         "html_theme_path": "[tibas.tt.get_path(), alabaster.get_path()]"
       },
       "display": "tibas.tt",
-      "pypi": "tibas.tt"
+      "pypi": "tibas-tt"
     },
     {
       "config": "topos-theme",
@@ -450,11 +455,6 @@
       },
       "display": "wild_sphinx_theme",
       "pypi": "wild-sphinx-theme"
-    },
-    {
-      "config": "sphinx_ustack_theme",
-      "display": "sphinx-ustack-theme",
-      "pypi": "sphinx-ustack-theme"
     },
     {
       "config": "yummy_sphinx_theme",

--- a/themes.json
+++ b/themes.json
@@ -331,6 +331,11 @@
       "pypi": "sphinx-sizzle-theme"
     },
     {
+      "config": "sphinx_susiai_theme",
+      "display": "sphinx-susiai-theme",
+      "pypi": "sphinx-susiai-theme"
+    },
+    {
       "config": {
         "_imports": [
           "sphinx_theme_pd"
@@ -357,9 +362,115 @@
       "pypi": "sphinx-uedoc-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "sphinxbootstrap4theme"
+        ],
+        "html_theme": "sphinxbootstrap4theme",
+        "html_theme_path": "[sphinxbootstrap4theme.get_path()]"
+      },
+      "display": "sphinxbootstrap4theme",
+      "pypi": "sphinxbootstrap4theme"
+    },
+    {
+      "config": "basicstrap",
+      "display": "sphinxjp.themes.basicstrap",
+      "pypi": "sphinxjp.themes.basicstrap"
+    },
+    {
+      "config": "dotted",
+      "display": "sphinxjp.themes.dotted",
+      "pypi": "sphinxjp.themes.dotted"
+    },
+    {
+      "config": "gopher",
+      "display": "sphinxjp.themes.gopher",
+      "pypi": "sphinxjp.themes.gopher"
+    },
+    {
+      "config": "htmlslide",
+      "display": "sphinxjp.themes.htmlslide",
+      "pypi": "sphinxjp.themes.htmlslide"
+    },
+    {
+      "config": "revealjs",
+      "display": "sphinxjp.themes.revealjs",
+      "pypi": "sphinxjp.themes.revealjs"
+    },
+    {
+      "config": "s6",
+      "display": "sphinxjp.themes.s6",
+      "pypi": "sphinxjp.themes.s6"
+    },
+    {
+      "config": "sphinxjp",
+      "display": "sphinxjp.themes.sphinxjp",
+      "pypi": "sphinxjp.themes.sphinxjp"
+    },
+    {
+      "config": "trstyle",
+      "display": "sphinxjp.themes.trstyle",
+      "pypi": "sphinxjp.themes.trstyle"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sunpy_sphinx_theme"
+        ],
+        "html_theme": "sunpy",
+        "html_theme_path": "sunpy_sphinx_theme.get_html_theme_path()"
+      },
+      "display": "sunpy-sphinx-theme",
+      "pypi": "sunpy-sphinx-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "tibas.tt",
+          "alabaster"
+        ],
+        "html_theme": "tt",
+        "html_theme_path": "[tibas.tt.get_path(), alabaster.get_path()]"
+      },
+      "display": "tibas.tt",
+      "pypi": "tibas.tt"
+    },
+    {
+      "config": "topos-theme",
+      "display": "topos-theme",
+      "pypi": "topos-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "wild_sphinx_theme"
+        ],
+        "html_theme": "wild",
+        "html_theme_path": "[wild_sphinx_theme.get_theme_dir()]"
+      },
+      "display": "wild_sphinx_theme",
+      "pypi": "wild-sphinx-theme"
+    },
+    {
       "config": "sphinx_ustack_theme",
       "display": "sphinx-ustack-theme",
       "pypi": "sphinx-ustack-theme"
+    },
+    {
+      "config": "yummy_sphinx_theme",
+      "display": "yummy-sphinx-theme",
+      "pypi": "yummy-sphinx-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "zerovm_sphinx_theme"
+        ],
+        "html_theme": "zerovm",
+        "html_theme_path": "[zerovm_sphinx_theme.theme_path]"
+      },
+      "display": "zerovm-sphinx-theme",
+      "pypi": "zerovm-sphinx-theme"
     },
     {
       "config": "agogo",


### PR DESCRIPTION
This time, I've ported multiple themes in one PR, in order to speed up things.

I've also started from the end of the list, for no particular reason.

This are the original `conf.py` entries:

zerovm-sphinx-theme:

```
html_theme = 'zerovm'
import zerovm_sphinx_theme
html_theme_path = [zerovm_sphinx_theme.theme_path]
```

yummy-sphinx-theme:

```
html_theme = 'yummy_sphinx_theme'
```

wild_sphinx_theme:

```
html_theme = 'wild'
import wild_sphinx_theme
html_theme_path = [wild_sphinx_theme.get_theme_dir()]
```

topos-theme:

```
html_theme = 'topos-theme'
```

tibas.tt:

```
html_theme = 'tt'
import tibas.tt as tt
import alabaster

html_theme_path = [ tt.get_path(), alabaster.get_path() ]
```

sunpy-sphinx-theme:

```
html_theme = 'sunpy'
import sunpy_sphinx_theme
html_theme_path = sunpy_sphinx_theme.get_html_theme_path()
```

sphinxjp.themes.trstyle:

```
html_theme = 'trstyle'
```

Same pattern for sphinxjp, s6, revealjs, htmlslide, gopher, dotted, basicstrap

sphinxbootstrap4theme:

```
html_theme = 'sphinxbootstrap4theme'
import sphinxbootstrap4theme
html_theme_path = [sphinxbootstrap4theme.get_path()]
```

sphinx-susiai-theme:

```
html_theme = 'sphinx_susiai_theme'
```

