### PR TITLE
Add 33 themes

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -21,6 +21,16 @@
       "pypi": "sphinx-rtd-theme"
     },
     {
+      "config": "aiohttp_theme",
+      "display": "aiohttp-theme",
+      "pypi": "aiohttp-theme"
+    },
+    {
+      "config": "asteroid_sphinx_theme",
+      "display": "asteroid-sphinx-theme",
+      "pypi": "asteroid-sphinx-theme"
+    },
+    {
       "config": "bootstrap-astropy",
       "display": "astropy-sphinx-theme",
       "pypi": "astropy-sphinx-theme"
@@ -38,9 +48,24 @@
       "pypi": "caktus-sphinx-theme"
     },
     {
+      "config": "catalyst_sphinx_theme",
+      "display": "catalyst-sphinx-theme",
+      "pypi": "catalyst-sphinx-theme"
+    },
+    {
       "config": "cloud",
       "display": "cloud_sptheme",
       "pypi": "cloud-sptheme"
+    },
+    {
+      "config": "dask_sphinx_theme",
+      "display": "dask-sphinx-theme",
+      "pypi": "dask-sphinx-theme"
+    },
+    {
+      "config": "divio_docs_theme",
+      "display": "divio-docs-theme",
+      "pypi": "divio-docs-theme"
     },
     {
       "config": {
@@ -55,6 +80,32 @@
       },
       "display": "edx-sphinx-theme",
       "pypi": "edx-sphinx-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "enthought_sphinx_theme"
+        ],
+        "html_theme": "enthought",
+        "html_theme_path": "[enthought_sphinx_theme.theme_path]"
+      },
+      "display": "enthought-sphinx-theme",
+      "pypi": "enthought-sphinx-theme"
+    },
+    {
+      "config": "f5_sphinx_theme",
+      "display": "f5-sphinx-theme",
+      "pypi": "f5-sphinx-theme"
+    },
+    {
+      "config": {
+        "_extensions": [
+          "faculty_sphinx_theme"
+        ],
+        "html_theme": "faculty-sphinx-theme"
+      },
+      "display": "faculty-sphinx-theme",
+      "pypi": "faculty-sphinx-theme"
     },
     {
       "config": "flask",
@@ -77,6 +128,17 @@
       },
       "display": "guzzle-sphinx-theme",
       "pypi": "guzzle-sphinx-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "hachibee_sphinx_theme"
+        ],
+        "html_theme": "hachibee",
+        "html_theme_path": "[hachibee_sphinx_theme.get_html_themes_path()]"
+      },
+      "display": "hachibee-sphinx-theme",
+      "pypi": "hachibee-sphinx-theme"
     },
     {
       "config": {
@@ -133,6 +195,17 @@
       "pypi": "kotti-docs-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "limix_sphinx_theme"
+        ],
+        "html_theme": "bootstrap-limix",
+        "html_theme_path": "limix_sphinx_theme.get_html_theme_path()"
+      },
+      "display": "limix-sphinx-theme",
+      "pypi": "limix-sphinx-theme"
+    },
+    {
       "config": "logilab",
       "display": "Logilab",
       "pypi": "logilab-sphinx-themes"
@@ -158,6 +231,20 @@
       },
       "display": "lsst-sphinx-bootstrap-theme",
       "pypi": "lsst-sphinx-bootstrap-theme"
+    },
+    {
+      "config": {
+        "_extensions": [
+          "maisie_sphinx_theme"
+        ],
+        "_imports": [
+          "maisie_sphinx_theme"
+        ],
+        "html_theme": "maisie_sphinx_theme",
+        "html_theme_path": "maisie_sphinx_theme.html_theme_path()"
+      },
+      "display": "Maisie-Sphinx-Theme",
+      "pypi": "maisie-sphinx-theme"
     },
     {
       "config": {
@@ -216,9 +303,19 @@
       "pypi": "pietroalbini-sphinx-themes"
     },
     {
+      "config": "psyneulink_sphinx_theme",
+      "display": "psyneulink-sphinx-theme",
+      "pypi": "psyneulink-sphinx-theme"
+    },
+    {
       "config": "python_docs_theme",
       "display": "Python Documentation Theme",
       "pypi": "python-docs-theme"
+    },
+    {
+      "config": "pytorch_sphinx_theme",
+      "display": "pytorch-sphinx-theme",
+      "pypi": "pytorch-sphinx-theme"
     },
     {
       "config": {
@@ -232,9 +329,27 @@
       "pypi": "quark-sphinx-theme"
     },
     {
+      "config": {
+        "html_theme": "renga"
+      },
+      "display": "renga-sphinx-theme",
+      "pypi": "renga-sphinx-theme"
+    },
+    {
       "config": "renku",
       "display": "renku-sphinx-theme",
       "pypi": "renku-sphinx-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "rtcat_sphinx_theme"
+        ],
+        "html_theme": "rtcat_sphinx_theme",
+        "html_theme_path": "[rtcat_sphinx_theme.get_html_theme_path()]"
+      },
+      "display": "rtcat-sphinx-theme",
+      "pypi": "rtcat-sphinx-theme"
     },
     {
       "config": {
@@ -259,6 +374,11 @@
       "pypi": "sphinx-adc-theme"
     },
     {
+      "config": "sphinx_aimms_theme",
+      "display": "sphinx-aimms-theme",
+      "pypi": "sphinx-aimms-theme"
+    },
+    {
       "config": {
         "_extensions": [
           "sphinx_ansible_theme.ext.pygments_lexer"
@@ -271,6 +391,11 @@
       },
       "display": "Reusable Ansible Theme",
       "pypi": "sphinx-ansible-theme"
+    },
+    {
+      "config": "sphinx_audeering_theme",
+      "display": "sphinx-audeering-theme",
+      "pypi": "sphinx-audeering-theme"
     },
     {
       "config": {
@@ -293,6 +418,11 @@
       },
       "display": "sphinx-better-theme",
       "pypi": "sphinx-better-theme"
+    },
+    {
+      "config": "sphinx_boogergreen_theme",
+      "display": "sphinx-boogergreen-theme",
+      "pypi": "sphinx-boogergreen-theme"
     },
     {
       "config": {
@@ -335,6 +465,17 @@
     {
       "config": {
         "_imports": [
+          "sphinx_compas_theme"
+        ],
+        "html_theme": "compas",
+        "html_theme_path": "sphinx_compas_theme.get_html_theme_path()"
+      },
+      "display": "sphinx-compas-theme",
+      "pypi": "sphinx-compas-theme"
+    },
+    {
+      "config": {
+        "_imports": [
           "corlab_theme"
         ],
         "html_theme": "corlab_theme",
@@ -360,14 +501,35 @@
       "pypi": "sphinx-drove-theme"
     },
     {
+      "config": "sphinx_enos_theme",
+      "display": "sphinx-enos-theme",
+      "pypi": "sphinx-enos-theme"
+    },
+    {
       "config": "sphinx_fossasia_theme",
       "display": "sphinx-fossasia-theme",
       "pypi": "sphinx-fossasia-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "sphinx_glpi_theme"
+        ],
+        "html_theme": "glpi",
+        "html_theme_path": "sphinx_glpi_theme.get_html_themes_path()"
+      },
+      "display": "sphinx-glpi-theme",
+      "pypi": "sphinx-glpi-theme"
+    },
+    {
       "config": "sphinx_ioam_theme",
       "display": "sphinx-ioam-theme",
       "pypi": "sphinx-ioam-theme"
+    },
+    {
+      "config": "sphinx_iowmd_theme",
+      "display": "sphinx-iowmd-theme",
+      "pypi": "sphinx-iowmd-theme"
     },
     {
       "config": "sphinx_material",
@@ -378,6 +540,11 @@
       "config": "sphinx_materialdesign_theme",
       "display": "sphinx_materialdesign_theme",
       "pypi": "sphinx-materialdesign-theme"
+    },
+    {
+      "config": "sphinx_mdolab_theme",
+      "display": "sphinx-mdolab-theme",
+      "pypi": "sphinx-mdolab-theme"
     },
     {
       "config": {
@@ -391,6 +558,17 @@
       "pypi": "sphinx-modern-theme"
     },
     {
+      "config": {
+        "_imports": [
+          "sphinx_nameko_theme"
+        ],
+        "html_theme": "nameko",
+        "html_theme_path": "[sphinx_nameko_theme.get_html_theme_path()]"
+      },
+      "display": "sphinx-nameko-theme",
+      "pypi": "sphinx-nameko-theme"
+    },
+    {
       "config": "nervproject",
       "display": "sphinx-nervproject-theme",
       "pypi": "sphinx-nervproject-theme"
@@ -399,6 +577,17 @@
       "config": "opnfv",
       "display": "sphinx-opnfv-theme",
       "pypi": "sphinx-opnfv-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_pangeo_theme"
+        ],
+        "html_theme": "pangeo",
+        "html_theme_path": "[sphinx_pangeo_theme.get_html_theme_path()]"
+      },
+      "display": "sphinx-pangeo-theme",
+      "pypi": "sphinx-pangeo-theme"
     },
     {
       "config": {
@@ -415,6 +604,17 @@
       "config": "press",
       "display": "press",
       "pypi": "sphinx-press-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_readable_theme"
+        ],
+        "html_theme": "readable",
+        "html_theme_path": "[sphinx_readable_theme.get_html_theme_path()]"
+      },
+      "display": "sphinx-readable-theme",
+      "pypi": "sphinx-readable-theme"
     },
     {
       "config": {
@@ -441,6 +641,24 @@
       "config": "sphinx_susiai_theme",
       "display": "sphinx-susiai-theme",
       "pypi": "sphinx-susiai-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_theme"
+        ],
+        "html_theme": "stanford_theme",
+        "html_theme_path": "[sphinx_theme.get_html_theme_path('stanford-theme')]"
+      },
+      "display": "sphinx-theme",
+      "pypi": "sphinx-theme"
+    },
+    {
+      "config": {
+        "html_theme": "material"
+      },
+      "display": "sphinx-theme-material",
+      "pypi": "sphinx-theme-material"
     },
     {
       "config": {
@@ -474,6 +692,16 @@
       "pypi": "sphinx-ustack-theme"
     },
     {
+      "config": "sphinx_veldus_theme",
+      "display": "sphinx-veldus-theme",
+      "pypi": "sphinx-veldus-theme"
+    },
+    {
+      "config": "sphinx_zon_theme",
+      "display": "sphinx-zon-theme",
+      "pypi": "sphinx-zon-theme"
+    },
+    {
       "config": {
         "_imports": [
           "sphinxbootstrap4theme"
@@ -493,6 +721,22 @@
       "config": "sphinxjp",
       "display": "sphinxjp.themes.sphinxjp",
       "pypi": "sphinxjp-themes-sphinxjp"
+    },
+    {
+      "config": {
+        "_imports": [
+          "stanford_theme"
+        ],
+        "html_theme": "stanford_theme",
+        "html_theme_path": "[stanford_theme.get_html_theme_path()]"
+      },
+      "display": "stanford-theme",
+      "pypi": "stanford-theme"
+    },
+    {
+      "config": "starling_theme",
+      "display": "starling-theme",
+      "pypi": "starling-theme"
     },
     {
       "config": {
@@ -532,6 +776,11 @@
       },
       "display": "wild_sphinx_theme",
       "pypi": "wild-sphinx-theme"
+    },
+    {
+      "config": "ydoc_theme",
+      "display": "ydoc-theme",
+      "pypi": "ydoc-theme"
     },
     {
       "config": "yummy_sphinx_theme",
@@ -588,255 +837,6 @@
       "config": "traditional",
       "display": "traditional",
       "pypi": "sphinx"
-    },
-    {
-      "config": {
-        "_extensions": [
-          "maisie_sphinx_theme"
-        ],
-        "_imports": [
-          "maisie_sphinx_theme"
-        ],
-        "html_theme": "maisie_sphinx_theme",
-        "html_theme_path": "maisie_sphinx_theme.html_theme_path()"
-      },
-      "display": "Maisie-Sphinx-Theme",
-      "pypi": "Maisie-Sphinx-Theme"
-    },
-    {
-      "config": "aiohttp_theme",
-      "display": "aiohttp-theme",
-      "pypi": "aiohttp-theme"
-    },
-    {
-      "config": "asteroid_sphinx_theme",
-      "display": "asteroid-sphinx-theme",
-      "pypi": "asteroid-sphinx-theme"
-    },
-    {
-      "config": "catalyst_sphinx_theme",
-      "display": "catalyst-sphinx-theme",
-      "pypi": "catalyst-sphinx-theme"
-    },
-    {
-      "config": "dask_sphinx_theme",
-      "display": "dask-sphinx-theme",
-      "pypi": "dask-sphinx-theme"
-    },
-    {
-      "config": "divio_docs_theme",
-      "display": "divio-docs-theme",
-      "pypi": "divio-docs-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "enthought_sphinx_theme"
-        ],
-        "html_theme": "enthought",
-        "html_theme_path": "[enthought_sphinx_theme.theme_path]"
-      },
-      "display": "enthought-sphinx-theme",
-      "pypi": "enthought-sphinx-theme"
-    },
-    {
-      "config": "f5_sphinx_theme",
-      "display": "f5-sphinx-theme",
-      "pypi": "f5-sphinx-theme"
-    },
-    {
-      "config": {
-        "_extensions": [
-          "faculty_sphinx_theme"
-        ],
-        "html_theme": "faculty-sphinx-theme"
-      },
-      "display": "faculty-sphinx-theme",
-      "pypi": "faculty-sphinx-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "hachibee_sphinx_theme"
-        ],
-        "html_theme": "hachibee",
-        "html_theme_path": "[hachibee_sphinx_theme.get_html_themes_path()]"
-      },
-      "display": "hachibee-sphinx-theme",
-      "pypi": "hachibee-sphinx-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "limix_sphinx_theme"
-        ],
-        "html_theme": "bootstrap-limix",
-        "html_theme_path": "limix_sphinx_theme.get_html_theme_path()"
-      },
-      "display": "limix-sphinx-theme",
-      "pypi": "limix-sphinx-theme"
-    },
-    {
-      "config": "psyneulink_sphinx_theme",
-      "display": "psyneulink-sphinx-theme",
-      "pypi": "psyneulink-sphinx-theme"
-    },
-    {
-      "config": "pytorch_sphinx_theme",
-      "display": "pytorch-sphinx-theme",
-      "pypi": "pytorch-sphinx-theme"
-    },
-    {
-      "config": {
-        "html_theme": "renga"
-      },
-      "display": "renga-sphinx-theme",
-      "pypi": "renga-sphinx-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "rtcat_sphinx_theme"
-        ],
-        "html_theme": "rtcat_sphinx_theme",
-        "html_theme_path": "[rtcat_sphinx_theme.get_html_theme_path()]"
-      },
-      "display": "rtcat-sphinx-theme",
-      "pypi": "rtcat-sphinx-theme"
-    },
-    {
-      "config": "sphinx_aimms_theme",
-      "display": "sphinx-aimms-theme",
-      "pypi": "sphinx-aimms-theme"
-    },
-    {
-      "config": "sphinx_audeering_theme",
-      "display": "sphinx-audeering-theme",
-      "pypi": "sphinx-audeering-theme"
-    },
-    {
-      "config": "sphinx_boogergreen_theme",
-      "display": "sphinx-boogergreen-theme",
-      "pypi": "sphinx-boogergreen-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_compas_theme"
-        ],
-        "html_theme": "compas",
-        "html_theme_path": "sphinx_compas_theme.get_html_theme_path()"
-      },
-      "display": "sphinx-compas-theme",
-      "pypi": "sphinx-compas-theme"
-    },
-    {
-      "config": "sphinx_enos_theme",
-      "display": "sphinx-enos-theme",
-      "pypi": "sphinx-enos-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_glpi_theme"
-        ],
-        "html_theme": "glpi",
-        "html_theme_path": "sphinx_glpi_theme.get_html_themes_path()"
-      },
-      "display": "sphinx-glpi-theme",
-      "pypi": "sphinx-glpi-theme"
-    },
-    {
-      "config": "sphinx_iowmd_theme",
-      "display": "sphinx-iowmd-theme",
-      "pypi": "sphinx-iowmd-theme"
-    },
-    {
-      "config": "sphinx_mdolab_theme",
-      "display": "sphinx-mdolab-theme",
-      "pypi": "sphinx-mdolab-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_nameko_theme"
-        ],
-        "html_theme": "nameko",
-        "html_theme_path": "[sphinx_nameko_theme.get_html_theme_path()]"
-      },
-      "display": "sphinx-nameko-theme",
-      "pypi": "sphinx-nameko-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_pangeo_theme"
-        ],
-        "html_theme": "pangeo",
-        "html_theme_path": "[sphinx_pangeo_theme.get_html_theme_path()]"
-      },
-      "display": "sphinx-pangeo-theme",
-      "pypi": "sphinx-pangeo-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_readable_theme"
-        ],
-        "html_theme": "readable",
-        "html_theme_path": "[sphinx_readable_theme.get_html_theme_path()]"
-      },
-      "display": "sphinx-readable-theme",
-      "pypi": "sphinx-readable-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_theme"
-        ],
-        "html_theme": "stanford_theme",
-        "html_theme_path": "[sphinx_theme.get_html_theme_path('stanford-theme')]"
-      },
-      "display": "sphinx-theme",
-      "pypi": "sphinx-theme"
-    },
-    {
-      "config": {
-        "html_theme": "material"
-      },
-      "display": "sphinx-theme-material",
-      "pypi": "sphinx-theme-material"
-    },
-    {
-      "config": "sphinx_veldus_theme",
-      "display": "sphinx-veldus-theme",
-      "pypi": "sphinx-veldus-theme"
-    },
-    {
-      "config": "sphinx_zon_theme",
-      "display": "sphinx-zon-theme",
-      "pypi": "sphinx-zon-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "stanford_theme"
-        ],
-        "html_theme": "stanford_theme",
-        "html_theme_path": "[stanford_theme.get_html_theme_path()]"
-      },
-      "display": "stanford-theme",
-      "pypi": "stanford-theme"
-    },
-    {
-      "config": "starling_theme",
-      "display": "starling-theme",
-      "pypi": "starling-theme"
-    },
-    {
-      "config": "ydoc_theme",
-      "display": "ydoc-theme",
-      "pypi": "ydoc-theme"
     }
   ]
 }

--- a/themes.json
+++ b/themes.json
@@ -588,6 +588,255 @@
       "config": "traditional",
       "display": "traditional",
       "pypi": "sphinx"
+    },
+    {
+      "config": {
+        "_extensions": [
+          "maisie_sphinx_theme"
+        ],
+        "_imports": [
+          "maisie_sphinx_theme"
+        ],
+        "html_theme": "maisie_sphinx_theme",
+        "html_theme_path": "maisie_sphinx_theme.html_theme_path()"
+      },
+      "display": "Maisie-Sphinx-Theme",
+      "pypi": "Maisie-Sphinx-Theme"
+    },
+    {
+      "config": "aiohttp_theme",
+      "display": "aiohttp-theme",
+      "pypi": "aiohttp-theme"
+    },
+    {
+      "config": "asteroid_sphinx_theme",
+      "display": "asteroid-sphinx-theme",
+      "pypi": "asteroid-sphinx-theme"
+    },
+    {
+      "config": "catalyst_sphinx_theme",
+      "display": "catalyst-sphinx-theme",
+      "pypi": "catalyst-sphinx-theme"
+    },
+    {
+      "config": "dask_sphinx_theme",
+      "display": "dask-sphinx-theme",
+      "pypi": "dask-sphinx-theme"
+    },
+    {
+      "config": "divio_docs_theme",
+      "display": "divio-docs-theme",
+      "pypi": "divio-docs-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "enthought_sphinx_theme"
+        ],
+        "html_theme": "enthought",
+        "html_theme_path": "[enthought_sphinx_theme.theme_path]"
+      },
+      "display": "enthought-sphinx-theme",
+      "pypi": "enthought-sphinx-theme"
+    },
+    {
+      "config": "f5_sphinx_theme",
+      "display": "f5-sphinx-theme",
+      "pypi": "f5-sphinx-theme"
+    },
+    {
+      "config": {
+        "_extensions": [
+          "faculty_sphinx_theme"
+        ],
+        "html_theme": "faculty-sphinx-theme"
+      },
+      "display": "faculty-sphinx-theme",
+      "pypi": "faculty-sphinx-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "hachibee_sphinx_theme"
+        ],
+        "html_theme": "hachibee",
+        "html_theme_path": "[hachibee_sphinx_theme.get_html_themes_path()]"
+      },
+      "display": "hachibee-sphinx-theme",
+      "pypi": "hachibee-sphinx-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "limix_sphinx_theme"
+        ],
+        "html_theme": "bootstrap-limix",
+        "html_theme_path": "limix_sphinx_theme.get_html_theme_path()"
+      },
+      "display": "limix-sphinx-theme",
+      "pypi": "limix-sphinx-theme"
+    },
+    {
+      "config": "psyneulink_sphinx_theme",
+      "display": "psyneulink-sphinx-theme",
+      "pypi": "psyneulink-sphinx-theme"
+    },
+    {
+      "config": "pytorch_sphinx_theme",
+      "display": "pytorch-sphinx-theme",
+      "pypi": "pytorch-sphinx-theme"
+    },
+    {
+      "config": {
+        "html_theme": "renga"
+      },
+      "display": "renga-sphinx-theme",
+      "pypi": "renga-sphinx-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "rtcat_sphinx_theme"
+        ],
+        "html_theme": "rtcat_sphinx_theme",
+        "html_theme_path": "[rtcat_sphinx_theme.get_html_theme_path()]"
+      },
+      "display": "rtcat-sphinx-theme",
+      "pypi": "rtcat-sphinx-theme"
+    },
+    {
+      "config": "sphinx_aimms_theme",
+      "display": "sphinx-aimms-theme",
+      "pypi": "sphinx-aimms-theme"
+    },
+    {
+      "config": "sphinx_audeering_theme",
+      "display": "sphinx-audeering-theme",
+      "pypi": "sphinx-audeering-theme"
+    },
+    {
+      "config": "sphinx_boogergreen_theme",
+      "display": "sphinx-boogergreen-theme",
+      "pypi": "sphinx-boogergreen-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_compas_theme"
+        ],
+        "html_theme": "compas",
+        "html_theme_path": "sphinx_compas_theme.get_html_theme_path()"
+      },
+      "display": "sphinx-compas-theme",
+      "pypi": "sphinx-compas-theme"
+    },
+    {
+      "config": "sphinx_enos_theme",
+      "display": "sphinx-enos-theme",
+      "pypi": "sphinx-enos-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_glpi_theme"
+        ],
+        "html_theme": "glpi",
+        "html_theme_path": "sphinx_glpi_theme.get_html_themes_path()"
+      },
+      "display": "sphinx-glpi-theme",
+      "pypi": "sphinx-glpi-theme"
+    },
+    {
+      "config": "sphinx_iowmd_theme",
+      "display": "sphinx-iowmd-theme",
+      "pypi": "sphinx-iowmd-theme"
+    },
+    {
+      "config": "sphinx_mdolab_theme",
+      "display": "sphinx-mdolab-theme",
+      "pypi": "sphinx-mdolab-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_nameko_theme"
+        ],
+        "html_theme": "nameko",
+        "html_theme_path": "[sphinx_nameko_theme.get_html_theme_path()]"
+      },
+      "display": "sphinx-nameko-theme",
+      "pypi": "sphinx-nameko-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_pangeo_theme"
+        ],
+        "html_theme": "pangeo",
+        "html_theme_path": "[sphinx_pangeo_theme.get_html_theme_path()]"
+      },
+      "display": "sphinx-pangeo-theme",
+      "pypi": "sphinx-pangeo-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_readable_theme"
+        ],
+        "html_theme": "readable",
+        "html_theme_path": "[sphinx_readable_theme.get_html_theme_path()]"
+      },
+      "display": "sphinx-readable-theme",
+      "pypi": "sphinx-readable-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "sphinx_theme"
+        ],
+        "html_theme": "stanford_theme",
+        "html_theme_path": "[sphinx_theme.get_html_theme_path('stanford-theme')]"
+      },
+      "display": "sphinx-theme",
+      "pypi": "sphinx-theme"
+    },
+    {
+      "config": {
+        "html_theme": "material"
+      },
+      "display": "sphinx-theme-material",
+      "pypi": "sphinx-theme-material"
+    },
+    {
+      "config": "sphinx_veldus_theme",
+      "display": "sphinx-veldus-theme",
+      "pypi": "sphinx-veldus-theme"
+    },
+    {
+      "config": "sphinx_zon_theme",
+      "display": "sphinx-zon-theme",
+      "pypi": "sphinx-zon-theme"
+    },
+    {
+      "config": {
+        "_imports": [
+          "stanford_theme"
+        ],
+        "html_theme": "stanford_theme",
+        "html_theme_path": "[stanford_theme.get_html_theme_path()]"
+      },
+      "display": "stanford-theme",
+      "pypi": "stanford-theme"
+    },
+    {
+      "config": "starling_theme",
+      "display": "starling-theme",
+      "pypi": "starling-theme"
+    },
+    {
+      "config": "ydoc_theme",
+      "display": "ydoc-theme",
+      "pypi": "ydoc-theme"
     }
   ]
 }


### PR DESCRIPTION
refs: #25 

add 33 themes.

### Themes packages in pypi

```
pip3 search theme  | grep -i Sphinx | cut -d " " -f 1  | sort | uniq > pip3_list.txt
```
### Current themes

```
jq -r '.themes[].pypi' themes.json  | sort | uniq > current_list.txt
```

### Counts

```
% wc -l  pip3_list.txt current_list.txt
  66 pip3_list.txt
  65 current_list.txt
```

### In pypi but not yet created

```
comm -23 --check-order pip3_list.txt current_list.txt > required.txt
wc -l reuired.txt
  50 required.txt
```

## generate script

https://gist.github.com/shirou/7107634e4d75a6f594606fb263462283

### skipped themes

These themes have an error and skipped. However, I think it can be generated by using some config.

```
    "autorch-sphinx-theme",  # no theme named 'pytorch_sphinx_theme' found (missing theme.conf?)
    "djangochurch-docs-theme",  # sphinx.errors.ThemeError: no theme named 'djangochurch_docs_theme' found
    "dkist-sphinx-theme",  # code missing from repo
    "epfl-sphinx-theme",  # code missing from repo
    "sphinx-django-theme",  # code missing from repo
    "sphinx-funtoo-theme",  # code missing from repo
    "sphinx-guillotina-theme",  # no theme named 'guillotina' found (missing theme.conf?)
    "sphinx-idf-theme",  # npm required
    "sphinx-heigvd-theme",  # No module named 'docutils'
    "sphinx-md-theme",  # TypeError: '>' not supported between instances of 'str' and 'int'
    "sphinx-seeta-theme",  # code missing from repo
    "sphinx-target-theme",  # code missing from repo
    "sphinx-yellowblue-theme",  # code missing from repo
    "sphinx-typlog-theme",  # jinja2.exceptions.UndefinedError: 'metatags' is undefined
    "sphinxawesome-theme",  # AttributeError: 'NoneType' object has no attribute 'replace'
    "stsci-rtd-theme",  # sphinx.errors.ThemeError: no theme named 'sphinx_rtd_theme' found, inherited by 'stsci_rtd_theme'
    "torchexpo-sphinx-theme",  # missing pythorch
```




