### PR TITLE
Remove not-good-for-reuse themes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 
 - repo: https://github.com/psf/black
-  rev: 19.10b0
+  rev: 20.8b1
   hooks:
     - id: black
 
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.2.0
+  rev: 5.8.0
   hooks:
   - id: isort
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 'v3.1.0'
+  rev: 'v3.4.0'
   hooks:
     - id: check-builtin-literals
     - id: check-added-large-files

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -143,8 +143,7 @@ def _theme_config_to_source_lines(config):
 
 
 def generate_sphinx_config_for(theme, *, at):
-    """Generate the Sphinx configuration file for this theme.
-    """
+    """Generate the Sphinx configuration file for this theme."""
     config_lines = _theme_config_to_source_lines(theme.config)
 
     with CONF_PY_TEMPLATE.open() as f:

--- a/themes.json
+++ b/themes.json
@@ -26,31 +26,9 @@
       "pypi": "aiohttp-theme"
     },
     {
-      "config": "asteroid_sphinx_theme",
-      "display": "asteroid-sphinx-theme",
-      "pypi": "asteroid-sphinx-theme"
-    },
-    {
       "config": "bootstrap-astropy",
       "display": "astropy-sphinx-theme",
       "pypi": "astropy-sphinx-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "caktus_theme"
-        ],
-        "html_sidebars": "caktus_theme.default_sidebars()",
-        "html_theme": "caktus",
-        "html_theme_path": "[caktus_theme.get_theme_dir()]"
-      },
-      "display": "Caktus",
-      "pypi": "caktus-sphinx-theme"
-    },
-    {
-      "config": "catalyst_sphinx_theme",
-      "display": "catalyst-sphinx-theme",
-      "pypi": "catalyst-sphinx-theme"
     },
     {
       "config": "cloud",
@@ -58,54 +36,9 @@
       "pypi": "cloud-sptheme"
     },
     {
-      "config": "dask_sphinx_theme",
-      "display": "dask-sphinx-theme",
-      "pypi": "dask-sphinx-theme"
-    },
-    {
-      "config": "divio_docs_theme",
-      "display": "divio-docs-theme",
-      "pypi": "divio-docs-theme"
-    },
-    {
-      "config": {
-        "_extensions": [
-          "edx_theme"
-        ],
-        "_imports": [
-          "edx_theme"
-        ],
-        "html_theme": "edx_theme",
-        "html_theme_path": "[edx_theme.get_html_theme_path()]"
-      },
-      "display": "edx-sphinx-theme",
-      "pypi": "edx-sphinx-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "enthought_sphinx_theme"
-        ],
-        "html_theme": "enthought",
-        "html_theme_path": "[enthought_sphinx_theme.theme_path]"
-      },
-      "display": "enthought-sphinx-theme",
-      "pypi": "enthought-sphinx-theme"
-    },
-    {
       "config": "f5_sphinx_theme",
       "display": "f5-sphinx-theme",
       "pypi": "f5-sphinx-theme"
-    },
-    {
-      "config": {
-        "_extensions": [
-          "faculty_sphinx_theme"
-        ],
-        "html_theme": "faculty-sphinx-theme"
-      },
-      "display": "faculty-sphinx-theme",
-      "pypi": "faculty-sphinx-theme"
     },
     {
       "config": "flask",
@@ -116,18 +49,6 @@
       "config": "groundwork",
       "display": "groundwork-sphinx-theme",
       "pypi": "groundwork-sphinx-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "guzzle_sphinx_theme"
-        ],
-        "html_theme": "guzzle_sphinx_theme",
-        "html_theme_path": "guzzle_sphinx_theme.html_theme_path()",
-        "html_translator_class": "'guzzle_sphinx_theme.HTMLTranslator'"
-      },
-      "display": "guzzle-sphinx-theme",
-      "pypi": "guzzle-sphinx-theme"
     },
     {
       "config": {
@@ -196,44 +117,6 @@
     },
     {
       "config": {
-        "_imports": [
-          "limix_sphinx_theme"
-        ],
-        "html_theme": "bootstrap-limix",
-        "html_theme_path": "limix_sphinx_theme.get_html_theme_path()"
-      },
-      "display": "limix-sphinx-theme",
-      "pypi": "limix-sphinx-theme"
-    },
-    {
-      "config": "logilab",
-      "display": "Logilab",
-      "pypi": "logilab-sphinx-themes"
-    },
-    {
-      "config": {
-        "_imports": [
-          "lsst_dd_rtd_theme"
-        ],
-        "html_theme": "lsst_dd_rtd_theme",
-        "html_theme_path": "[lsst_dd_rtd_theme.get_html_theme_path()]"
-      },
-      "display": "LSST Design Documents Theme",
-      "pypi": "lsst-dd-rtd-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "lsst_sphinx_bootstrap_theme"
-        ],
-        "html_theme": "lsst_sphinx_bootstrap_theme",
-        "html_theme_path": "[lsst_sphinx_bootstrap_theme.get_html_theme_path()]"
-      },
-      "display": "lsst-sphinx-bootstrap-theme",
-      "pypi": "lsst-sphinx-bootstrap-theme"
-    },
-    {
-      "config": {
         "_extensions": [
           "maisie_sphinx_theme"
         ],
@@ -283,17 +166,6 @@
     {
       "config": {
         "_imports": [
-          "ovs_sphinx_theme"
-        ],
-        "html_theme": "ovs",
-        "html_theme_path": "[ovs_sphinx_theme.get_theme_dir()]"
-      },
-      "display": "ovs-sphinx-theme",
-      "pypi": "ovs-sphinx-theme"
-    },
-    {
-      "config": {
-        "_imports": [
           "pietroalbini_sphinx_themes"
         ],
         "html_theme": "pietroalbini",
@@ -303,35 +175,14 @@
       "pypi": "pietroalbini-sphinx-themes"
     },
     {
-      "config": "psyneulink_sphinx_theme",
-      "display": "psyneulink-sphinx-theme",
-      "pypi": "psyneulink-sphinx-theme"
-    },
-    {
       "config": "pydata_sphinx_theme",
       "display": "PyData Sphinx Theme",
       "pypi": "pydata-sphinx-theme"
     },
     {
-      "config": {
-        "_imports": [
-          "pylons_sphinx_themes"
-        ],
-        "html_theme": "pylons",
-        "html_theme_path": "pylons_sphinx_themes.get_html_themes_path()"
-      },
-      "display": "pylons-sphinx-themes (pylons)",
-      "pypi": "pylons-sphinx-themes"
-    },
-    {
       "config": "python_docs_theme",
       "display": "Python Documentation Theme",
       "pypi": "python-docs-theme"
-    },
-    {
-      "config": "pytorch_sphinx_theme",
-      "display": "pytorch-sphinx-theme",
-      "pypi": "pytorch-sphinx-theme"
     },
     {
       "config": {
@@ -355,13 +206,6 @@
       "config": "renku",
       "display": "renku-sphinx-theme",
       "pypi": "renku-sphinx-theme"
-    },
-    {
-      "config": {
-        "html_theme": "press"
-      },
-      "display": "romnnn-sphinx-press-theme",
-      "pypi": "romnnn-sphinx-press-theme"
     },
     {
       "config": {
@@ -397,11 +241,6 @@
       "pypi": "sphinx-adc-theme"
     },
     {
-      "config": "sphinx_aimms_theme",
-      "display": "sphinx-aimms-theme",
-      "pypi": "sphinx-aimms-theme"
-    },
-    {
       "config": {
         "_extensions": [
           "sphinx_ansible_theme.ext.pygments_lexer"
@@ -414,11 +253,6 @@
       },
       "display": "Reusable Ansible Theme",
       "pypi": "sphinx-ansible-theme"
-    },
-    {
-      "config": "sphinx_audeering_theme",
-      "display": "sphinx-audeering-theme",
-      "pypi": "sphinx-audeering-theme"
     },
     {
       "config": {
@@ -455,17 +289,6 @@
     {
       "config": {
         "_imports": [
-          "sphinx_boost"
-        ],
-        "html_theme": "boost",
-        "html_theme_path": "[sphinx_boost.get_html_theme_path()]"
-      },
-      "display": "sphinx-boost",
-      "pypi": "sphinx-boost"
-    },
-    {
-      "config": {
-        "_imports": [
           "sphinx_bootstrap_theme"
         ],
         "html_theme": "bootstrap",
@@ -475,58 +298,14 @@
       "pypi": "sphinx-bootstrap-theme"
     },
     {
-      "config": {
-        "_imports": [
-          "sphinx_catalystcloud_theme"
-        ],
-        "html_theme": "sphinx_catalystcloud_theme",
-        "html_theme_path": "[sphinx_catalystcloud_theme.get_html_theme_path()]"
-      },
-      "display": "sphinx-catalystcloud-theme",
-      "pypi": "sphinx-catalystcloud-theme"
-    },
-    {
       "config": "sphinx_celery",
       "display": "Celery Theme",
       "pypi": "sphinx-celery"
     },
     {
-      "config": {
-        "_imports": [
-          "sphinx_compas_theme"
-        ],
-        "html_theme": "compas",
-        "html_theme_path": "sphinx_compas_theme.get_html_theme_path()"
-      },
-      "display": "sphinx-compas-theme",
-      "pypi": "sphinx-compas-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "corlab_theme"
-        ],
-        "html_theme": "corlab_theme",
-        "html_theme_path": "[corlab_theme.get_theme_dir()]"
-      },
-      "display": "sphinx-corlab-theme",
-      "pypi": "sphinx-corlab-theme"
-    },
-    {
       "config": "sphinx_documatt_theme",
       "display": "Documatt Theme",
       "pypi": "sphinx-documatt-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_drove_theme"
-        ],
-        "html_theme": "sphinx_drove_theme",
-        "html_theme_path": "[sphinx_drove_theme.get_html_theme_path()]"
-      },
-      "display": "sphinx_drove_theme",
-      "pypi": "sphinx-drove-theme"
     },
     {
       "config": "sphinx_enos_theme",
@@ -541,17 +320,6 @@
     {
       "config": {
         "_imports": [
-          "sphinx_glpi_theme"
-        ],
-        "html_theme": "glpi",
-        "html_theme_path": "sphinx_glpi_theme.get_html_themes_path()"
-      },
-      "display": "sphinx-glpi-theme",
-      "pypi": "sphinx-glpi-theme"
-    },
-    {
-      "config": {
-        "_imports": [
           "sphinx_hand_theme"
         ],
         "html_theme": "sphinx_hand_theme",
@@ -559,11 +327,6 @@
       },
       "display": "sphinx_hand_theme",
       "pypi": "sphinx-hand-theme"
-    },
-    {
-      "config": "sphinx_ioam_theme",
-      "display": "sphinx-ioam-theme",
-      "pypi": "sphinx-ioam-theme"
     },
     {
       "config": "sphinx_iowmd_theme",
@@ -574,49 +337,6 @@
       "config": "sphinx_material",
       "display": "sphinx-material",
       "pypi": "sphinx-material"
-    },
-    {
-      "config": "sphinx_materialdesign_theme",
-      "display": "sphinx_materialdesign_theme",
-      "pypi": "sphinx-materialdesign-theme"
-    },
-    {
-      "config": "sphinx_mdolab_theme",
-      "display": "sphinx-mdolab-theme",
-      "pypi": "sphinx-mdolab-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_modern_theme"
-        ],
-        "html_theme": "sphinx_modern_theme",
-        "html_theme_path": "[sphinx_modern_theme.get_html_theme_path()]"
-      },
-      "display": "sphinx-modern-theme",
-      "pypi": "sphinx-modern-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_nameko_mw_theme"
-        ],
-        "html_theme": "nameko-mw",
-        "html_theme_path": "[sphinx_nameko_mw_theme.get_html_theme_path()]"
-      },
-      "display": "sphinx-nameko-mw-theme",
-      "pypi": "sphinx-nameko-mw-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinx_nameko_theme"
-        ],
-        "html_theme": "nameko",
-        "html_theme_path": "[sphinx_nameko_theme.get_html_theme_path()]"
-      },
-      "display": "sphinx-nameko-theme",
-      "pypi": "sphinx-nameko-theme"
     },
     {
       "config": "nervproject",
@@ -688,11 +408,6 @@
       "pypi": "sphinx-sizzle-theme"
     },
     {
-      "config": "sphinx_susiai_theme",
-      "display": "sphinx-susiai-theme",
-      "pypi": "sphinx-susiai-theme"
-    },
-    {
       "config": {
         "_imports": [
           "sphinx_theme"
@@ -722,11 +437,6 @@
       "pypi": "sphinx-theme-pd"
     },
     {
-      "config": "sphinx_typo3_theme",
-      "display": "TYPO3 theme for docs.typo3.org",
-      "pypi": "sphinx-typo3-theme"
-    },
-    {
       "config": {
         "_extensions": [
           "uedoc_theme"
@@ -745,22 +455,6 @@
       "config": "sphinx_veldus_theme",
       "display": "sphinx-veldus-theme",
       "pypi": "sphinx-veldus-theme"
-    },
-    {
-      "config": "sphinx_zon_theme",
-      "display": "sphinx-zon-theme",
-      "pypi": "sphinx-zon-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sphinxbootstrap4theme"
-        ],
-        "html_theme": "sphinxbootstrap4theme",
-        "html_theme_path": "[sphinxbootstrap4theme.get_path()]"
-      },
-      "display": "sphinxbootstrap4theme",
-      "pypi": "sphinxbootstrap4theme"
     },
     {
       "config": {
@@ -789,22 +483,6 @@
       "pypi": "stanford-theme"
     },
     {
-      "config": "starling_theme",
-      "display": "starling-theme",
-      "pypi": "starling-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "sunpy_sphinx_theme"
-        ],
-        "html_theme": "sunpy",
-        "html_theme_path": "sunpy_sphinx_theme.get_html_theme_path()"
-      },
-      "display": "sunpy-sphinx-theme",
-      "pypi": "sunpy-sphinx-theme"
-    },
-    {
       "config": {
         "_imports": [
           "tibas.tt",
@@ -820,17 +498,6 @@
       "config": "topos-theme",
       "display": "topos-theme",
       "pypi": "topos-theme"
-    },
-    {
-      "config": {
-        "_imports": [
-          "wild_sphinx_theme"
-        ],
-        "html_theme": "wild",
-        "html_theme_path": "[wild_sphinx_theme.get_theme_dir()]"
-      },
-      "display": "wild_sphinx_theme",
-      "pypi": "wild-sphinx-theme"
     },
     {
       "config": "ydoc_theme",

--- a/themes.json
+++ b/themes.json
@@ -175,11 +175,6 @@
       "pypi": "pietroalbini-sphinx-themes"
     },
     {
-      "config": "pydata_sphinx_theme",
-      "display": "PyData Sphinx Theme",
-      "pypi": "pydata-sphinx-theme"
-    },
-    {
       "config": "python_docs_theme",
       "display": "Python Documentation Theme",
       "pypi": "python-docs-theme"


### PR DESCRIPTION
Either due to being exceedingly tied to an organisation, or due to not
being meaningfully different from an existing theme.

