### PR TITLE
Fix insipid theme settings

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -42,8 +42,9 @@
     },
     {
       "config": {
-        "html_add_permalinks": "'\\N{SECTION SIGN}'",
         "html_context": "{'display_github': True, 'github_user': 'sphinx-themes', 'github_repo': 'sphinx-themes.org', 'conf_py_path': '/sample-docs/', 'commit': 'master'}",
+        "html_copy_source": "False",
+        "html_permalinks_icon": "'\\N{SECTION SIGN}'",
         "html_theme": "insipid"
       },
       "display": "Insipid",


### PR DESCRIPTION
`html_add_permalinks` has been deprecated and should be replaced with `html_permalinks_icon`.

And `html_copy_source` has been removed in 1b264e3c020c645b9fd3ec7886ded64c1e356b5e, even though it is necessary to make the Github source links work (see https://insipid-sphinx-theme.readthedocs.io/en/0.2.4/configuration.html#confval-html_show_sourcelink).