### PR TITLE
Reduce configuration flags for insipid theme

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -49,13 +49,11 @@
     },
     {
       "config": {
-        "html_context": "{'display_github': True, 'github_user': 'sphinx-themes', 'github_repo': 'sphinx-themes.org', 'conf_py_path': '/sample-docs/', 'commit': 'master'}",
-        "html_copy_source": "False",
         "html_permalinks_icon": "'\\N{SECTION SIGN}'",
         "html_theme": "insipid"
       },
       "display": "Insipid",
-      "documentation": "https://insipid-sphinx-theme.readthedocs.io/en/latest/",
+      "documentation": "https://insipid-sphinx-theme.readthedocs.io/",
       "pypi": "insipid-sphinx-theme"
     },
     {


### PR DESCRIPTION
Since the configuration is now shown in the sample pages, I think adding those complicated options is a net negative.

It shows the nice "view source on Github" feature, but this isn't worth confusing potential users with a complicated config.