### PR TITLE
Fix Italics Typesetting `_everything_` -> `*everything*`

### DIFF
--- a/sample-docs/kitchen-sink/index.rst
+++ b/sample-docs/kitchen-sink/index.rst
@@ -8,7 +8,7 @@ Kitchen Sink
 
 This section exists as a dump of all the things that Sphinx has.
 
-It has exactly one goal: to be a good checklist of things to stylise within Sphinx. This also means that it is a complete showcase of _everything_ that vanilla Sphinx provides and includes all sorts of edge cases.
+It has exactly one goal: to be a good checklist of things to stylise within Sphinx. This also means that it is a complete showcase of *everything* that vanilla Sphinx provides and includes all sorts of edge cases.
 
 .. toctree::
     :titlesonly:


### PR DESCRIPTION
Tiny change. 

The typesetting for "everything" on the kitchen sink page is making use of underscores which does not render as italics with RST + sphinx. 

Simply change `_everything_` -> `*everything*`