### PR TITLE
Add versionadded, changed, deprecated admonitions

### DIFF
--- a/sample-docs/kitchen-sink/admonitions.rst
+++ b/sample-docs/kitchen-sink/admonitions.rst
@@ -106,12 +106,18 @@ Sphinx provides several different types of admonitions.
 
 .. versionadded:: v0.1.1
 
+   Here's a version added message.
+
 ``versionchanged``
 ==================
 
 .. versionchanged:: v0.1.1
 
+   Here's a version changed message.
+
 ``deprecated``
 ==============
 
 .. deprecated:: v0.1.1
+
+   Here's a deprecation message.

--- a/sample-docs/kitchen-sink/admonitions.rst
+++ b/sample-docs/kitchen-sink/admonitions.rst
@@ -100,7 +100,6 @@ Sphinx provides several different types of admonitions.
 .. warning::
 
    Reader discretion is strongly advised.
-   
 ``versionadded``
 ================
 

--- a/sample-docs/kitchen-sink/admonitions.rst
+++ b/sample-docs/kitchen-sink/admonitions.rst
@@ -100,3 +100,18 @@ Sphinx provides several different types of admonitions.
 .. warning::
 
    Reader discretion is strongly advised.
+   
+``versionadded``
+================
+
+.. versionadded:: v0.1.1
+
+``versionchanged``
+==================
+
+.. versionchanged:: v0.1.1
+
+``deprecated``
+==============
+
+.. deprecated:: v0.1.1


### PR DESCRIPTION
This adds examples of the three "version admonitions", which seem to be special cases of admonitions. I couldn't find them in the sphinx themes gallery but have seen many docs using them.

Example of what they look like in the pydata theme:

![image](https://user-images.githubusercontent.com/1839645/179465033-9e43c500-6c6b-4165-b580-d4cc0f2a6e45.png)
