### PR TITLE
Include `nox -s publish` as a command in theme addition workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ The most valuable contribution to this project would be to contribute more aweso
 - Clone your fork.
 - Edit [`themes.json`], adding the new theme's configuration (described below) to it.
 - Run `nox -s lint`, to ensure the entry is positioned properly.
+- Run `nox -s publish -- <your-theme-pypi-name>`, to build your theme's preview locally.
 - Commit and push changes.
 - File a pull request!
 


### PR DESCRIPTION
This makes the details of how to build/preview your theme locally more
prominent in this document, making it more easily discovered.