### PR TITLE
Include sphinx.ext.todo in the build configuration

### DIFF
--- a/src/templates/conf.template.py
+++ b/src/templates/conf.template.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
+    "sphinx.ext.todo",
 ]
 
 extlinks = {


### PR DESCRIPTION
There is a build fail in PyData Demo:

ERROR: Unknown directive type "todo".

I believe that propose config template change will resolve it.
<img width="622" alt="Screenshot 2022-10-01 at 15 53 46" src="https://user-images.githubusercontent.com/14884856/193412859-707a0233-65de-4daa-85c8-aa9c72b88e46.png">
