### PR TITLE
Don't install a pre-release of Sphinx

### DIFF
--- a/src/generate_sample_sites.py
+++ b/src/generate_sample_sites.py
@@ -44,7 +44,7 @@ async def generate_site(
         progress.advance(task, 1)
 
         progress.log(f"[yellow]{theme.name}[reset]: Installing packages...")
-        await env.install("--pre", "sphinx")
+        await env.install("sphinx")
         progress.advance(task, 1)
         await env.install(theme.pypi_package)
         progress.advance(task, 1)


### PR DESCRIPTION
This allows for the default presentation to rely on the last stable Sphinx release.

Toward #114, x-ref #113 