### PR TITLE
Render TODO admonitions in sample docs

### DIFF
--- a/src/templates/conf.template.py
+++ b/src/templates/conf.template.py
@@ -25,6 +25,8 @@ extlinks = {
     "pypi": ("https://pypi.org/project/%s/", ""),
 }
 
+todo_include_todos = True
+
 # -- Theme-specific -----------------------------------------------------------
 
 rst_prolog = """


### PR DESCRIPTION
Fix #117 

as mentioned in the [docs](https://www.sphinx-doc.org/en/master/usage/extensions/todo.html#configuration), the todo admonitions are hidden by default. the `todo_include_todos` configuration parameter needs to be set to `True` in the conf.py file