### PR TITLE
Add "conestack" theme to themes.json

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -132,6 +132,12 @@
       "pypi": "cloud-sptheme"
     },
     {
+      "config": "conestack",
+      "display": "Conestack",
+      "documentation": "https://sphinx-conestack-theme.readthedocs.io/en/latest/",
+      "pypi": "sphinx-conestack-theme"
+    },
+    {
       "config": "sphinx_documatt_theme",
       "display": "Documatt",
       "pypi": "sphinx-documatt-theme"


### PR DESCRIPTION
It is meant as a base theme for common re-use, is published at PyPI and matured already.

It is not project specific, even if it was made to have a Bootstrap 5 based theme for Conestack, therefore the name.
There are no project specific parts in the theme except the logo, which can be changed with ease.

The theme is well documented at https://sphinx-conestack-theme.readthedocs.io/en/latest/
