### PR TITLE
Add more inline markup examples to admonition samples

### DIFF
--- a/sample-docs/kitchen-sink/admonitions.rst
+++ b/sample-docs/kitchen-sink/admonitions.rst
@@ -17,12 +17,16 @@ Sphinx provides several different types of admonitions.
    This is what admonitions are a special case of, according to the docutils
    documentation.
 
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+
 ``admonition``
 ==============
 
 .. admonition:: The one with the custom titles
 
    It's got a certain charm to it.
+
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
 
 ``attention``
 =============
@@ -31,12 +35,16 @@ Sphinx provides several different types of admonitions.
 
    Climate change is real.
 
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+
 ``caution``
 ===========
 
 .. caution::
 
    Cliff ahead: Don't drive off it.
+
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
 
 ``danger``
 ==========
@@ -45,12 +53,16 @@ Sphinx provides several different types of admonitions.
 
    Mad scientist at work!
 
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+
 ``error``
 =========
 
 .. error::
 
    Does not compute.
+
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
 
 ``hint``
 ========
@@ -59,12 +71,16 @@ Sphinx provides several different types of admonitions.
 
    Insulators insulate, until they are subject to ______ voltage.
 
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+
 ``important``
 =============
 
 .. important::
 
    Tech is not neutral, nor is it apolitical.
+
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
 
 ``note``
 ========
@@ -73,12 +89,16 @@ Sphinx provides several different types of admonitions.
 
    This is a note.
 
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+
 ``seealso``
 ===========
 
 .. seealso::
 
    Other relevant information.
+
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
 
 ``tip``
 =======
@@ -87,12 +107,16 @@ Sphinx provides several different types of admonitions.
 
    25% if the service is good.
 
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+
 ``todo``
 ========
 
 .. todo::
 
    This needs the ``sphinx.ext.todo`` extension.
+
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
 
 ``warning``
 ===========
@@ -101,12 +125,16 @@ Sphinx provides several different types of admonitions.
 
    Reader discretion is strongly advised.
 
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+
 ``versionadded``
 ================
 
 .. versionadded:: v0.1.1
 
    Here's a version added message.
+
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
 
 ``versionchanged``
 ==================
@@ -115,9 +143,13 @@ Sphinx provides several different types of admonitions.
 
    Here's a version changed message.
 
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+
 ``deprecated``
 ==============
 
 .. deprecated:: v0.1.1
 
    Here's a deprecation message.
+
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.


### PR DESCRIPTION
The theme I am developing colors links like the admonition's text color (which follows the admonition's main color), so this helped debugging.
Maybe it's useful for someone else too?