### PR TITLE
Fix link redirects

### DIFF
--- a/sample-docs/kitchen-sink/admonitions.rst
+++ b/sample-docs/kitchen-sink/admonitions.rst
@@ -17,7 +17,7 @@ Sphinx provides several different types of admonitions.
    This is what admonitions are a special case of, according to the docutils
    documentation.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``admonition``
 ==============
@@ -26,7 +26,7 @@ Sphinx provides several different types of admonitions.
 
    It's got a certain charm to it.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``attention``
 =============
@@ -35,7 +35,7 @@ Sphinx provides several different types of admonitions.
 
    Climate change is real.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``caution``
 ===========
@@ -44,7 +44,7 @@ Sphinx provides several different types of admonitions.
 
    Cliff ahead: Don't drive off it.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``danger``
 ==========
@@ -53,7 +53,7 @@ Sphinx provides several different types of admonitions.
 
    Mad scientist at work!
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``error``
 =========
@@ -62,7 +62,7 @@ Sphinx provides several different types of admonitions.
 
    Does not compute.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``hint``
 ========
@@ -71,7 +71,7 @@ Sphinx provides several different types of admonitions.
 
    Insulators insulate, until they are subject to ______ voltage.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``important``
 =============
@@ -80,7 +80,7 @@ Sphinx provides several different types of admonitions.
 
    Tech is not neutral, nor is it apolitical.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``note``
 ========
@@ -89,7 +89,7 @@ Sphinx provides several different types of admonitions.
 
    This is a note.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``seealso``
 ===========
@@ -98,7 +98,7 @@ Sphinx provides several different types of admonitions.
 
    Other relevant information.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``tip``
 =======
@@ -107,7 +107,7 @@ Sphinx provides several different types of admonitions.
 
    25% if the service is good.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``todo``
 ========
@@ -116,7 +116,7 @@ Sphinx provides several different types of admonitions.
 
    This needs the ``sphinx.ext.todo`` extension.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``warning``
 ===========
@@ -125,7 +125,7 @@ Sphinx provides several different types of admonitions.
 
    Reader discretion is strongly advised.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``versionadded``
 ================
@@ -134,7 +134,7 @@ Sphinx provides several different types of admonitions.
 
    Here's a version added message.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``versionchanged``
 ==================
@@ -143,7 +143,7 @@ Sphinx provides several different types of admonitions.
 
    Here's a version changed message.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
 
 ``deprecated``
 ==============
@@ -152,4 +152,4 @@ Sphinx provides several different types of admonitions.
 
    Here's a deprecation message.
 
-   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/>`_, and more.
+   We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.

--- a/sample-docs/kitchen-sink/generic.rst
+++ b/sample-docs/kitchen-sink/generic.rst
@@ -28,9 +28,9 @@ a :sup:`superscript`, :emphasis:`emphasis`, :strong:`strong`, and
 Hyperlinks
 ----------
 
-It is a website, so it'll have hyperlinks like http://www.python.org (inline),
+It is a website, so it'll have hyperlinks like https://www.python.org (inline),
 or Python_ (external reference), example_ (internal reference),
-`Python web site <http://www.python.org>`__ (external hyperlinks with embedded
+`Python web site <https://www.python.org>`__ (external hyperlinks with embedded
 URI), footnote references (manually numbered [1]_, anonymous auto-numbered [#]_,
 labeled auto-numbered [#label]_, or symbolic [*]_), citation references ([12]_),
 substitution references (|example|), and _`inline hyperlink targets`
@@ -199,7 +199,7 @@ Targets_.
 
 Explicit external targets are interpolated into references such as "Python_".
 
-.. _Python: http://www.python.org/
+.. _Python: https://www.python.org/
 
 Targets may be indirect and anonymous.  Thus `this phrase`__ may also
 refer to the Targets_ section.

--- a/sample-docs/kitchen-sink/generic.rst
+++ b/sample-docs/kitchen-sink/generic.rst
@@ -28,9 +28,9 @@ a :sup:`superscript`, :emphasis:`emphasis`, :strong:`strong`, and
 Hyperlinks
 ----------
 
-It is a website, so it'll have hyperlinks like https://www.python.org (inline),
+It is a website, so it'll have hyperlinks like https://www.python.org/ (inline),
 or Python_ (external reference), example_ (internal reference),
-`Python web site <https://www.python.org>`__ (external hyperlinks with embedded
+`Python web site <https://www.python.org/>`__ (external hyperlinks with embedded
 URI), footnote references (manually numbered [1]_, anonymous auto-numbered [#]_,
 labeled auto-numbered [#label]_, or symbolic [*]_), citation references ([12]_),
 substitution references (|example|), and _`inline hyperlink targets`

--- a/sample-docs/kitchen-sink/lists.rst
+++ b/sample-docs/kitchen-sink/lists.rst
@@ -189,13 +189,13 @@ Second list level
 ^^^^^^^^^^^^^^^^^
 
 - here is a list in a second-level section.
-- `yahoo <https://www.yahoo.com>`_
-- `yahoo <https://www.yahoo.com>`_
+- `yahoo <https://www.yahoo.com/>`_
+- `yahoo <https://www.yahoo.com/>`_
 
-  - `yahoo <https://www.yahoo.com>`_
+  - `yahoo <https://www.yahoo.com/>`_
   - here is an inner bullet ``oh``
 
-    - one more ``with an inline literally``. `yahoo <https://www.yahoo.com>`_
+    - one more ``with an inline literally``. `yahoo <https://www.yahoo.com/>`_
 
       heh heh. child. try to beat this embed:
 
@@ -204,8 +204,8 @@ Second list level
           :linenos:
           :lines: 10-20
 
-  - and another. `yahoo <https://www.yahoo.com>`_
-  - `yahoo <https://www.yahoo.com>`_
+  - and another. `yahoo <https://www.yahoo.com/>`_
+  - `yahoo <https://www.yahoo.com/>`_
   - ``hi``
 - how about an admonition?
 
@@ -217,15 +217,15 @@ Second list level
 But deeper down the rabbit hole
 """""""""""""""""""""""""""""""
 
-- I kept saying that, "deeper down the rabbit hole". `yahoo <https://www.yahoo.com>`_
+- I kept saying that, "deeper down the rabbit hole". `yahoo <https://www.yahoo.com/>`_
 
-  - I cackle at night `yahoo <https://www.yahoo.com>`_.
+  - I cackle at night `yahoo <https://www.yahoo.com/>`_.
 - I'm so lonely here in GZ ``guangzhou``
-- A man of python destiny, hopes and dreams. `yahoo <https://www.yahoo.com>`_
+- A man of python destiny, hopes and dreams. `yahoo <https://www.yahoo.com/>`_
 
-  - `yahoo <https://www.yahoo.com>`_
+  - `yahoo <https://www.yahoo.com/>`_
 
-    - `yahoo <https://www.yahoo.com>`_ ``hi``
+    - `yahoo <https://www.yahoo.com/>`_ ``hi``
     - ``destiny``
 
 Hlists

--- a/sample-docs/kitchen-sink/lists.rst
+++ b/sample-docs/kitchen-sink/lists.rst
@@ -189,13 +189,13 @@ Second list level
 ^^^^^^^^^^^^^^^^^
 
 - here is a list in a second-level section.
-- `yahoo <http://www.yahoo.com>`_
-- `yahoo <http://www.yahoo.com>`_
+- `yahoo <https://www.yahoo.com>`_
+- `yahoo <https://www.yahoo.com>`_
 
-  - `yahoo <http://www.yahoo.com>`_
+  - `yahoo <https://www.yahoo.com>`_
   - here is an inner bullet ``oh``
 
-    - one more ``with an inline literally``. `yahoo <http://www.yahoo.com>`_
+    - one more ``with an inline literally``. `yahoo <https://www.yahoo.com>`_
 
       heh heh. child. try to beat this embed:
 
@@ -204,8 +204,8 @@ Second list level
           :linenos:
           :lines: 10-20
 
-  - and another. `yahoo <http://www.yahoo.com>`_
-  - `yahoo <http://www.yahoo.com>`_
+  - and another. `yahoo <https://www.yahoo.com>`_
+  - `yahoo <https://www.yahoo.com>`_
   - ``hi``
 - how about an admonition?
 
@@ -217,15 +217,15 @@ Second list level
 But deeper down the rabbit hole
 """""""""""""""""""""""""""""""
 
-- I kept saying that, "deeper down the rabbit hole". `yahoo <http://www.yahoo.com>`_
+- I kept saying that, "deeper down the rabbit hole". `yahoo <https://www.yahoo.com>`_
 
-  - I cackle at night `yahoo <http://www.yahoo.com>`_.
+  - I cackle at night `yahoo <https://www.yahoo.com>`_.
 - I'm so lonely here in GZ ``guangzhou``
-- A man of python destiny, hopes and dreams. `yahoo <http://www.yahoo.com>`_
+- A man of python destiny, hopes and dreams. `yahoo <https://www.yahoo.com>`_
 
-  - `yahoo <http://www.yahoo.com>`_
+  - `yahoo <https://www.yahoo.com>`_
 
-    - `yahoo <http://www.yahoo.com>`_ ``hi``
+    - `yahoo <https://www.yahoo.com>`_ ``hi``
     - ``destiny``
 
 Hlists


### PR DESCRIPTION
When running `sphinx-build -b linkcheck`, there are several links reported as broken, but are redirects. This PR updates the links to their current ones.

Closes #149

Supersedes https://github.com/sphinx-themes/sphinx-themes.org/pull/150