### PR TITLE
Add --fail-on-warning to build command

### DIFF
--- a/sample-docs/kitchen-sink/api.rst
+++ b/sample-docs/kitchen-sink/api.rst
@@ -25,5 +25,5 @@ Using Sphinx's :any:`sphinx.ext.autodoc` plugin, it is possible to auto-generate
         # Don't show class signature with the class' name.
         autodoc_class_signature = "separated"
 
-.. automodule:: urllib.parse
+.. automodule:: code
     :members:

--- a/sample-docs/kitchen-sink/blocks.rst
+++ b/sample-docs/kitchen-sink/blocks.rst
@@ -135,7 +135,7 @@ They can be quoted without indentation::
 >
 > Why didn't I think of that?
 
-.. literalinclude:: ../../../src/furo/__init__.py
+.. literalinclude:: ../../noxfile.py
     :language: python
     :caption: Literal includes can also have captions.
     :linenos:

--- a/sample-docs/kitchen-sink/generic.rst
+++ b/sample-docs/kitchen-sink/generic.rst
@@ -268,4 +268,4 @@ voluptatem officia culpa optio atque. Quaerat sed quibusdam ratione nam.
 Download Links
 ==============
 
-:download:`This long long long long long long long long long long long long long long long download link should wrap white-spaces <https://picsum.photos/200/200
+:download:`This long long long long long long long long long long long long long long long download link should wrap white-spaces <https://picsum.photos/200/200>`

--- a/sample-docs/kitchen-sink/lists.rst
+++ b/sample-docs/kitchen-sink/lists.rst
@@ -199,7 +199,7 @@ Second list level
 
       heh heh. child. try to beat this embed:
 
-      .. literalinclude:: ../../../src/furo/__init__.py
+      .. literalinclude:: ../../noxfile.py
           :language: python
           :linenos:
           :lines: 10-20

--- a/src/generate_sample_sites.py
+++ b/src/generate_sample_sites.py
@@ -62,6 +62,7 @@ async def generate_site(
             "--verbose",
             "--builder=dirhtml",
             f"--conf-dir={env.path}",
+            "--fail-on-warning",
             str(BUILD["sources"]),
             str(destination_path),
         )

--- a/src/generate_sample_sites.py
+++ b/src/generate_sample_sites.py
@@ -59,9 +59,9 @@ async def generate_site(
         progress.log(f"[yellow]{theme.name}[reset]: Building site...")
         returncode, output = await env.run(
             "sphinx-build",
-            "-v",
-            "-b=dirhtml",
-            f"-c={env.path}",
+            "--verbose",
+            "--builder=dirhtml",
+            f"--conf-dir={env.path}",
             str(BUILD["sources"]),
             str(destination_path),
         )


### PR DESCRIPTION
Closes #112 
Affects #132, by moving away from urllib.parse.

