### PR TITLE
close unclosed download role

### DIFF
--- a/sample-docs/kitchen-sink/generic.rst
+++ b/sample-docs/kitchen-sink/generic.rst
@@ -268,4 +268,4 @@ voluptatem officia culpa optio atque. Quaerat sed quibusdam ratione nam.
 Download Links
 ==============
 
-:download:`This long long long long long long long long long long long long long long long download link should wrap white-spaces <https://picsum.photos/200/200
+:download:`This long long long long long long long long long long long long long long long download link should wrap white-spaces <https://picsum.photos/200/200>`


### PR DESCRIPTION
last line of `sample-docs/kitchen-sink/generic.rst` had an unclosed `:download:` role... until now.