### PR TITLE
Re-revert Kitchen Sink API example

### DIFF
--- a/sample-docs/kitchen-sink/api.rst
+++ b/sample-docs/kitchen-sink/api.rst
@@ -25,5 +25,5 @@ Using Sphinx's :any:`sphinx.ext.autodoc` plugin, it is possible to auto-generate
         # Don't show class signature with the class' name.
         autodoc_class_signature = "separated"
 
-.. automodule:: urllib.parse
+.. automodule:: code
     :members:


### PR DESCRIPTION
https://github.com/sphinx-themes/sphinx-themes.org/pull/171 fixed https://github.com/sphinx-themes/sphinx-themes.org/issues/132 but was clobbered in a revert in https://github.com/sphinx-themes/sphinx-themes.org/pull/174. This PR restores the API example so that it no longer emits an error from urllib.

https://github.com/sphinx-themes/sphinx-themes.org/pull/157 would be a fuller demo of autodoc.