### PR TITLE
Add napoleon extension for all_in_one_restructuredtext.py showcase file

### DIFF
--- a/src/templates/conf.template.py
+++ b/src/templates/conf.template.py
@@ -20,8 +20,9 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
     "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
 ]
 
 extlinks = {


### PR DESCRIPTION
*(This PR is based on/includes #179.)*

The recently merged #157 adds `all_in_one_restructuredtext.py` which needs the napoleon extension for some of its docstrings, but I had forgotten to include it in that PR (I don't have a setup where I can completely build the project locally).