### PR TITLE
Add Shibuya

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -283,6 +283,12 @@
       "pypi": "mozilla-sphinx-theme"
     },
     {
+      "config": "shibuya",
+      "display": "Shibuya",
+      "documentation": "https://shibuya.lepture.com/",
+      "pypi": "shibuya"
+    },
+    {
       "config": "sizzle",
       "display": "Sizzle",
       "documentation": "https://docs.red-dove.com/sphinx_sizzle_theme/index.html",


### PR DESCRIPTION
I propose to add [Shibuya](https://github.com/lepture/shibuya), an actively maintained Sphinx theme that is extremely popular and feature rich.

CC @lepture