### PR TITLE
Remove warnings from Kitchen Sink all_in_one_restructuredtext.py

### DIFF
--- a/sample-docs/kitchen-sink/all_in_one_restructuredtext.py
+++ b/sample-docs/kitchen-sink/all_in_one_restructuredtext.py
@@ -180,7 +180,7 @@ class AllInOne:
         return my_var
 
     async def my_async_method(self, my_param: ParameterT = "default_value") -> ReturnT:
-        """An :term:`async` method.
+        """An async method.
 
         Text at end of docstring.
         """


### PR DESCRIPTION
There is no Glossary in this repo, and there is no term for `async`, not even in the Python docs.