### PR TITLE
Set COLUMNS for wider output in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: 0 0 * * MON # Run every Monday at 00:00 UTC
 
+env:
+  COLUMNS: 120
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The logging setup and use of `rich` for tracebacks makes exceptions hard to read in CI:
```
[18:55:35] Fail: sphinx-adc-theme                    generate_sample_sites.py:80
           ╭── Traceback (most recent call last) ──╮                            
           │ /home/runner/work/sphinx-themes.org/s │                            
           │ phinx-themes.org/src/generate_sample_ │                            
           │ sites.py:78 in generate_site          │                            
           │                                       │                            
           │    75 │   │   │   │   " stderr ".cent │                            
           │    76 │   │   │   │   stderr.decode() │                            
           │    77 │   │   │   ]                   │                            
           │ ❱  78 │   │   │   raise Exception("\n │                            
           │    79 │   except Exception as e:      │                            
           │    80 │   │   progress.log(f"Fail: [r │                            
           │    81 │   │   destination_path.mkdir( │                            
           ╰───────────────────────────────────────╯                            
```
This PR sets `COLUMNS` to get a wider display. With a value of `120`:
```
           Fail: sphinx-adc-theme                                                            generate_sample_sites.py:80
           ╭────────────────────── Traceback (most recent call last) ──────────────────────╮                            
           │ /home/runner/work/sphinx-themes.org/sphinx-themes.org/src/generate_sample_sit │                            
           │ es.py:78 in generate_site                                                     │                            
           │                                                                               │                            
           │    75 │   │   │   │   " stderr ".center(88, "="),                             │                            
           │    76 │   │   │   │   stderr.decode(),                                        │                            
           │    77 │   │   │   ]                                                           │                            
           │ ❱  78 │   │   │   raise Exception("\n".join(message))                         │                            
           │    79 │   except Exception as e:                                              │                            
           │    80 │   │   progress.log(f"Fail: [red]{theme.name}[reset]", rich.traceback. │                            
           │    81 │   │   destination_path.mkdir(parents=True, exist_ok=True)             │                            
           ╰───────────────────────────────────────────────────────────────────────────────╯                            
```
Should we go even wider?
