### PR TITLE
Added `manticore-sphinx-theme`

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -19,12 +19,6 @@
       "pypi": "furo"
     },
     {
-      "config": "manticore_sphinx_theme",
-      "display": "Manticore",
-      "documentation": "https://manticore-projects.github.io/manticore-sphinx-theme/",
-      "pypi": "manticore-sphinx-theme"
-    },
-    {
       "config": "shibuya",
       "display": "Shibuya",
       "documentation": "https://shibuya.lepture.com/",
@@ -77,7 +71,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_adc_theme"],
+        "_imports": [
+          "sphinx_adc_theme"
+        ],
         "html_theme": "sphinx_adc_theme",
         "html_theme_path": "[sphinx_adc_theme.get_html_theme_path()]"
       },
@@ -95,7 +91,9 @@
     },
     {
       "config": {
-        "_extensions": ["sphinxjp.themes.basicstrap"],
+        "_extensions": [
+          "sphinxjp.themes.basicstrap"
+        ],
         "html_theme": "basicstrap"
       },
       "display": "Basicstrap",
@@ -103,7 +101,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_bernard_theme"],
+        "_imports": [
+          "sphinx_bernard_theme"
+        ],
         "html_theme": "sphinx_bernard_theme",
         "html_theme_path": "[sphinx_bernard_theme.get_html_theme_path()]"
       },
@@ -112,7 +112,9 @@
     },
     {
       "config": {
-        "_imports": ["better"],
+        "_imports": [
+          "better"
+        ],
         "html_theme": "better",
         "html_theme_path": "[better.better_theme_path]"
       },
@@ -121,7 +123,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_bootstrap_theme"],
+        "_imports": [
+          "sphinx_bootstrap_theme"
+        ],
         "html_theme": "bootstrap",
         "html_theme_path": "sphinx_bootstrap_theme.get_html_theme_path()"
       },
@@ -162,7 +166,9 @@
     },
     {
       "config": {
-        "_imports": ["hachibee_sphinx_theme"],
+        "_imports": [
+          "hachibee_sphinx_theme"
+        ],
         "html_theme": "hachibee",
         "html_theme_path": "[hachibee_sphinx_theme.get_html_themes_path()]"
       },
@@ -176,7 +182,9 @@
     },
     {
       "config": {
-        "_imports": ["kotti_docs_theme"],
+        "_imports": [
+          "kotti_docs_theme"
+        ],
         "html_theme": "kotti_docs_theme",
         "html_theme_path": "[kotti_docs_theme.get_theme_dir()]"
       },
@@ -185,8 +193,12 @@
     },
     {
       "config": {
-        "_extensions": ["maisie_sphinx_theme"],
-        "_imports": ["maisie_sphinx_theme"],
+        "_extensions": [
+          "maisie_sphinx_theme"
+        ],
+        "_imports": [
+          "maisie_sphinx_theme"
+        ],
         "html_theme": "maisie_sphinx_theme",
         "html_theme_path": "maisie_sphinx_theme.html_theme_path()"
       },
@@ -194,8 +206,16 @@
       "pypi": "maisie-sphinx-theme"
     },
     {
+      "config": "manticore_sphinx_theme",
+      "display": "Manticore",
+      "documentation": "https://manticore-projects.github.io/manticore-sphinx-theme/",
+      "pypi": "manticore-sphinx-theme"
+    },
+    {
       "config": {
-        "_imports": ["murray"],
+        "_imports": [
+          "murray"
+        ],
         "html_theme": "murray",
         "html_theme_path": "[murray.get_html_theme_path()]"
       },
@@ -204,7 +224,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_nameko_theme"],
+        "_imports": [
+          "sphinx_nameko_theme"
+        ],
         "html_theme": "nameko",
         "html_theme_path": "[sphinx_nameko_theme.get_html_theme_path()]"
       },
@@ -219,7 +241,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_theme_pd"],
+        "_imports": [
+          "sphinx_theme_pd"
+        ],
         "html_theme": "sphinx_theme_pd",
         "html_theme_path": "[sphinx_theme_pd.get_html_theme_path()]"
       },
@@ -228,7 +252,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_pdj_theme"],
+        "_imports": [
+          "sphinx_pdj_theme"
+        ],
         "html_theme": "sphinx_pdj_theme",
         "html_theme_path": "[sphinx_pdj_theme.get_html_theme_path()]"
       },
@@ -242,7 +268,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_readable_theme"],
+        "_imports": [
+          "sphinx_readable_theme"
+        ],
         "html_theme": "readable",
         "html_theme_path": "[sphinx_readable_theme.get_html_theme_path()]"
       },
@@ -251,7 +279,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_redactor_theme"],
+        "_imports": [
+          "sphinx_redactor_theme"
+        ],
         "html_theme": "sphinx_redactor_theme",
         "html_theme_path": "[sphinx_redactor_theme.get_html_theme_path()]"
       },
@@ -265,7 +295,10 @@
     },
     {
       "config": {
-        "_imports": ["os", "mozilla_sphinx_theme"],
+        "_imports": [
+          "os",
+          "mozilla_sphinx_theme"
+        ],
         "html_theme": "mozilla",
         "html_theme_path": "[os.path.dirname(mozilla_sphinx_theme.__file__)]"
       },
@@ -280,7 +313,9 @@
     },
     {
       "config": {
-        "_imports": ["solar_theme"],
+        "_imports": [
+          "solar_theme"
+        ],
         "html_theme": "solar_theme",
         "html_theme_path": "[solar_theme.theme_path]"
       },
@@ -289,7 +324,9 @@
     },
     {
       "config": {
-        "_imports": ["sphinx_theme"],
+        "_imports": [
+          "sphinx_theme"
+        ],
         "html_theme": "stanford_theme",
         "html_theme_path": "[sphinx_theme.get_html_theme_path('stanford-theme')]"
       },
@@ -303,7 +340,9 @@
     },
     {
       "config": {
-        "_extensions": ["sphinx_wagtail_theme"],
+        "_extensions": [
+          "sphinx_wagtail_theme"
+        ],
         "html_theme": "sphinx_wagtail_theme"
       },
       "display": "Wagtail",
@@ -317,7 +356,9 @@
     },
     {
       "config": {
-        "_imports": ["zerovm_sphinx_theme"],
+        "_imports": [
+          "zerovm_sphinx_theme"
+        ],
         "html_theme": "zerovm",
         "html_theme_path": "[zerovm_sphinx_theme.theme_path]"
       },
@@ -326,7 +367,10 @@
     },
     {
       "config": {
-        "_imports": ["tibas.tt", "alabaster"],
+        "_imports": [
+          "tibas.tt",
+          "alabaster"
+        ],
         "html_theme": "tt",
         "html_theme_path": "[tibas.tt.get_path(), alabaster.get_path()]"
       },

--- a/themes.json
+++ b/themes.json
@@ -19,6 +19,12 @@
       "pypi": "furo"
     },
     {
+      "config": "manticore_sphinx_theme",
+      "display": "Manticore",
+      "documentation": "https://manticore-projects.github.io/manticore-sphinx-theme/",
+      "pypi": "manticore-sphinx-theme"
+    },
+    {
       "config": "shibuya",
       "display": "Shibuya",
       "documentation": "https://shibuya.lepture.com/",
@@ -71,9 +77,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_adc_theme"
-        ],
+        "_imports": ["sphinx_adc_theme"],
         "html_theme": "sphinx_adc_theme",
         "html_theme_path": "[sphinx_adc_theme.get_html_theme_path()]"
       },
@@ -91,9 +95,7 @@
     },
     {
       "config": {
-        "_extensions": [
-          "sphinxjp.themes.basicstrap"
-        ],
+        "_extensions": ["sphinxjp.themes.basicstrap"],
         "html_theme": "basicstrap"
       },
       "display": "Basicstrap",
@@ -101,9 +103,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_bernard_theme"
-        ],
+        "_imports": ["sphinx_bernard_theme"],
         "html_theme": "sphinx_bernard_theme",
         "html_theme_path": "[sphinx_bernard_theme.get_html_theme_path()]"
       },
@@ -112,9 +112,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "better"
-        ],
+        "_imports": ["better"],
         "html_theme": "better",
         "html_theme_path": "[better.better_theme_path]"
       },
@@ -123,9 +121,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_bootstrap_theme"
-        ],
+        "_imports": ["sphinx_bootstrap_theme"],
         "html_theme": "bootstrap",
         "html_theme_path": "sphinx_bootstrap_theme.get_html_theme_path()"
       },
@@ -166,9 +162,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "hachibee_sphinx_theme"
-        ],
+        "_imports": ["hachibee_sphinx_theme"],
         "html_theme": "hachibee",
         "html_theme_path": "[hachibee_sphinx_theme.get_html_themes_path()]"
       },
@@ -182,9 +176,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "kotti_docs_theme"
-        ],
+        "_imports": ["kotti_docs_theme"],
         "html_theme": "kotti_docs_theme",
         "html_theme_path": "[kotti_docs_theme.get_theme_dir()]"
       },
@@ -193,12 +185,8 @@
     },
     {
       "config": {
-        "_extensions": [
-          "maisie_sphinx_theme"
-        ],
-        "_imports": [
-          "maisie_sphinx_theme"
-        ],
+        "_extensions": ["maisie_sphinx_theme"],
+        "_imports": ["maisie_sphinx_theme"],
         "html_theme": "maisie_sphinx_theme",
         "html_theme_path": "maisie_sphinx_theme.html_theme_path()"
       },
@@ -207,9 +195,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "murray"
-        ],
+        "_imports": ["murray"],
         "html_theme": "murray",
         "html_theme_path": "[murray.get_html_theme_path()]"
       },
@@ -218,9 +204,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_nameko_theme"
-        ],
+        "_imports": ["sphinx_nameko_theme"],
         "html_theme": "nameko",
         "html_theme_path": "[sphinx_nameko_theme.get_html_theme_path()]"
       },
@@ -235,9 +219,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_theme_pd"
-        ],
+        "_imports": ["sphinx_theme_pd"],
         "html_theme": "sphinx_theme_pd",
         "html_theme_path": "[sphinx_theme_pd.get_html_theme_path()]"
       },
@@ -246,9 +228,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_pdj_theme"
-        ],
+        "_imports": ["sphinx_pdj_theme"],
         "html_theme": "sphinx_pdj_theme",
         "html_theme_path": "[sphinx_pdj_theme.get_html_theme_path()]"
       },
@@ -262,9 +242,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_readable_theme"
-        ],
+        "_imports": ["sphinx_readable_theme"],
         "html_theme": "readable",
         "html_theme_path": "[sphinx_readable_theme.get_html_theme_path()]"
       },
@@ -273,9 +251,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_redactor_theme"
-        ],
+        "_imports": ["sphinx_redactor_theme"],
         "html_theme": "sphinx_redactor_theme",
         "html_theme_path": "[sphinx_redactor_theme.get_html_theme_path()]"
       },
@@ -289,10 +265,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "os",
-          "mozilla_sphinx_theme"
-        ],
+        "_imports": ["os", "mozilla_sphinx_theme"],
         "html_theme": "mozilla",
         "html_theme_path": "[os.path.dirname(mozilla_sphinx_theme.__file__)]"
       },
@@ -307,9 +280,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "solar_theme"
-        ],
+        "_imports": ["solar_theme"],
         "html_theme": "solar_theme",
         "html_theme_path": "[solar_theme.theme_path]"
       },
@@ -318,9 +289,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "sphinx_theme"
-        ],
+        "_imports": ["sphinx_theme"],
         "html_theme": "stanford_theme",
         "html_theme_path": "[sphinx_theme.get_html_theme_path('stanford-theme')]"
       },
@@ -334,9 +303,7 @@
     },
     {
       "config": {
-        "_extensions": [
-          "sphinx_wagtail_theme"
-        ],
+        "_extensions": ["sphinx_wagtail_theme"],
         "html_theme": "sphinx_wagtail_theme"
       },
       "display": "Wagtail",
@@ -350,9 +317,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "zerovm_sphinx_theme"
-        ],
+        "_imports": ["zerovm_sphinx_theme"],
         "html_theme": "zerovm",
         "html_theme_path": "[zerovm_sphinx_theme.theme_path]"
       },
@@ -361,10 +326,7 @@
     },
     {
       "config": {
-        "_imports": [
-          "tibas.tt",
-          "alabaster"
-        ],
+        "_imports": ["tibas.tt", "alabaster"],
         "html_theme": "tt",
         "html_theme_path": "[tibas.tt.get_path(), alabaster.get_path()]"
       },


### PR DESCRIPTION
A new, clean BULMA-CSS based theme, developed from scratch. https://pypi.org/project/manticore-sphinx-theme/

## Features

- Bulma-based — uses Bulma's SASS architecture for consistent, modern styling
- No NPM required — compiles with Python libsass or standalone dart-sass
- RTD-style layout — fixed sidebar, scrollable content, right-rail TOC
- Corporate design — professional colour palette, clean typography (Source Sans 3 + JetBrains Mono)
- Fully responsive — mobile sidebar, touch-friendly, print stylesheet
- Customisable — override colours and fonts via html_theme_options or SASS variables
- Accessible — ARIA landmarks, keyboard navigation, skip links
- Lightweight JS — vanilla JavaScript for sidebar toggle, scroll-spy, and keyboard shortcuts
- Sphinx 7+ / 9.x compatible — uses the standard theme API
